### PR TITLE
Overload the slice reading functions

### DIFF
--- a/src/pe64/imports.rs
+++ b/src/pe64/imports.rs
@@ -62,7 +62,7 @@ pub struct Imports<'a, P> {
 impl<'a, P: Pe<'a> + Copy> Imports<'a, P> {
 	pub(crate) fn new(pe: P) -> Result<Imports<'a, P>> {
 		let datadir = pe.data_directory().get(IMAGE_DIRECTORY_ENTRY_IMPORT).ok_or(Error::OOB)?;
-		let image = pe.derva_slice_f(datadir.VirtualAddress, |image: &IMAGE_IMPORT_DESCRIPTOR| image.is_null())?;
+		let image = pe.derva_slice(datadir.VirtualAddress, |image: &IMAGE_IMPORT_DESCRIPTOR| image.is_null())?;
 		Ok(Imports { pe, image })
 	}
 	/// Gets the PE instance.
@@ -121,11 +121,11 @@ impl<'a, P: Pe<'a> + Copy> Desc<'a, P> {
 	/// Otherwise these contain references to the imported functions.
 	/// See [`import_from_va`](struct.Desc.html#import_from_va) to get their names.
 	pub fn iat(&self) -> Result<slice::Iter<'a, Va>> {
-		self.pe.derva_slice_f(self.image.FirstThunk, |&va| va == BADVA).map(|iat| iat.iter())
+		self.pe.derva_slice(self.image.FirstThunk, |&va| va == BADVA).map(|iat| iat.iter())
 	}
 	/// Gets the import name table.
 	pub fn int(self) -> Result<IntIter<'a, P>> {
-		let slice = self.pe.derva_slice_f(self.image.OriginalFirstThunk, |&va| va == BADVA)?;
+		let slice = self.pe.derva_slice(self.image.OriginalFirstThunk, |&va| va == BADVA)?;
 		Ok(IntIter {
 			pe: self.pe,
 			iter: slice.iter(),

--- a/src/pe64/tls.rs
+++ b/src/pe64/tls.rs
@@ -66,7 +66,7 @@ impl<'a, P: Pe<'a> + Copy> Tls<'a, P> {
 	}
 	pub fn callbacks(&self) -> Result<&'a [Va]> {
 		let rva = self.pe.va_to_rva(self.image.AddressOfCallBacks)?;
-		self.pe.derva_slice_f(rva, |&callback| callback == BADVA)
+		self.pe.derva_slice(rva, |&callback| callback == BADVA)
 	}
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,11 +9,13 @@ mod c_str;
 mod wide_str;
 mod pod;
 mod offset;
+mod slice_len;
 
 pub use self::c_str::CStr;
 pub use self::wide_str::WideStr;
 pub use self::pod::Pod;
 pub use self::offset::Offset;
+pub use self::slice_len::SliceLen;
 
 /// Splits a slice at the point defined by the callback.
 #[inline]

--- a/src/util/slice_len.rs
+++ b/src/util/slice_len.rs
@@ -1,0 +1,52 @@
+use ::std::{mem, slice};
+
+use super::Pod;
+
+/// Helper trait representing the length of an array.
+///
+/// The length of an array can be specified by a known length of type `usize`.
+///
+/// Sometimes the length of an array is determined by a [sentinel value](https://en.wikipedia.org/wiki/Sentinel_value), a special value of `T` which marks the end of the array.
+/// The length of the array is then specified by a callable with parameter `&'a T` returning a `bool` indicating if this value is the sentinel.
+///
+/// This trait has no usefulness outside `Pe::deref_slice` and `Pe::derva_slice` and should be considered an implementation detail...
+pub trait SliceLen<'a, T: Pod> {
+	fn min_size(&self) -> Option<usize>;
+	unsafe fn slice_len(self, bytes: &'a [u8]) -> Option<&'a [T]>;
+}
+
+impl<'a, T: Pod> SliceLen<'a, T> for usize {
+	#[inline]
+	fn min_size(&self) -> Option<usize> { mem::size_of::<T>().checked_mul(*self) }
+	#[inline]
+	unsafe fn slice_len(self, bytes: &'a [u8]) -> Option<&'a [T]> {
+		// Safe because the bytes slice should have at least `min_size()` length
+		Some(slice::from_raw_parts(bytes.as_ptr() as *const T, self))
+	}
+}
+impl<'a, T: Pod, F: FnMut(&'a T) -> bool> SliceLen<'a, T> for F {
+	#[inline]
+	fn min_size(&self) -> Option<usize> { Some(0) }
+	#[inline]
+	unsafe fn slice_len(mut self, bytes: &'a [u8]) -> Option<&'a [T]> {
+		let size_of_t = mem::size_of::<T>();
+		let mut len = 0;
+		let mut size = 0;
+		loop {
+			// Safety critical OOB check
+			if size + size_of_t > bytes.len() {
+				return None;
+			}
+			// Safe because size is checked above and T is Pod
+			let s = bytes.as_ptr().offset(size as isize) as *const T;
+			if self(&*s) {
+				let p = slice::from_raw_parts(bytes.as_ptr() as *const T, len);
+				return Some(p);
+			}
+			size += size_of_t;
+			len += 1;
+		}
+	}
+}
+// Needs Specialization
+// impl<'a, 'v, T: Pod + PartialEq> SliceLen<'a, T> for &'v T {}


### PR DESCRIPTION
Introduce the trait `SliceLen` implemented for

* `usize` to indicate an array with known length

* `FnMut(&T) -> bool` to scan for the sentinel value

Further development probably requires some form of specialization.