### PR TITLE
Refactor PE Reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["parsing", "command-line-utilities"]
 
 license = "MIT"
 
+[features]
+unsafe_alignment = []
+
 [badges]
 appveyor = { repository = "CasualX/pelite", branch = "master", service = "github" }
 

--- a/src/pe64/debug.rs
+++ b/src/pe64/debug.rs
@@ -109,7 +109,7 @@ impl<'a, P: Pe<'a> + Copy> Dir<'a, P> {
 	}
 	/// Gets the referenced debug info.
 	pub fn info(&self) -> Result<Info<'a>> {
-		let bytes = self.pe.slice_rva(self.image.AddressOfRawData, self.image.SizeOfData as usize, 4)?;
+		let bytes = self.pe.slice(self.image.AddressOfRawData, self.image.SizeOfData as usize, 4)?;
 		match self.image.Type {
 			IMAGE_DEBUG_TYPE_CODEVIEW => {
 				if bytes.len() >= 4 {

--- a/src/pe64/exports.rs
+++ b/src/pe64/exports.rs
@@ -86,7 +86,7 @@ impl<'a, P: Pe<'a> + Copy> Exports<'a, P> {
 	}
 	/// Gets the export directory's name for this library.
 	pub fn dll_name(&self) -> Result<&'a CStr> {
-		self.pe.derva_c_str(self.image.Name)
+		self.pe.derva_str(self.image.Name)
 	}
 	/// Gets the ordinal base for the exported functions.
 	///
@@ -130,7 +130,7 @@ impl<'a, P: Pe<'a> + Copy> Exports<'a, P> {
 			Ok(Export::None)
 		}
 		else if self.is_forwarded(*rva) {
-			let fwd = self.pe.derva_c_str(*rva)?;
+			let fwd = self.pe.derva_str(*rva)?;
 			Ok(Export::Forward(fwd))
 		}
 		else {
@@ -196,7 +196,7 @@ impl<'a, P: Pe<'a> + Copy> By<'a, P> {
 		while lower_bound != upper_bound {
 			let i = lower_bound + (upper_bound - lower_bound) / 2;
 			let name_rva = self.names[i];
-			let name_it = self.exp.pe.derva_c_str(name_rva)?.as_ref();
+			let name_it = self.exp.pe.derva_str(name_rva)?.as_ref();
 			use ::std::cmp::Ordering::*;
 			match name.cmp(name_it) {
 				Less => upper_bound = i,
@@ -243,7 +243,7 @@ impl<'a, P: Pe<'a> + Copy> By<'a, P> {
 	/// Looks up the name for a hint.
 	pub fn hint_name(&self, hint: usize) -> Result<&'a CStr> {
 		let &name_rva = self.names.get(hint).ok_or(Error::OOB)?;
-		self.exp.pe.derva_c_str(name_rva)
+		self.exp.pe.derva_str(name_rva)
 	}
 	/// Given an index in the functions array, gets the named export.
 	///
@@ -255,7 +255,7 @@ impl<'a, P: Pe<'a> + Copy> By<'a, P> {
 			Some(hint) => {
 				// Lookup the name
 				let name_rva = self.names[hint];
-				let name = self.exp.pe.derva_c_str(name_rva)?;
+				let name = self.exp.pe.derva_str(name_rva)?;
 				Ok(Import::ByName { hint, name })
 			},
 			None => {

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -19,35 +19,59 @@ impl<'a> PeFile<'a> {
 		let _ = validate_headers(image)?;
 		Ok(PeFile { image })
 	}
+	fn find_section(&self, rva: Rva, min_size: usize) -> Result<&'a [u8]> {
+		// Can't reuse `self.rva_to_file_offset` because it doesn't return the size of the section
+		for it in self.section_headers() {
+			if rva >= it.VirtualAddress && rva < (it.VirtualAddress + it.VirtualSize) {
+				if rva < (it.VirtualAddress + it.SizeOfRawData) {
+					let start = (rva - it.VirtualAddress + it.PointerToRawData) as FileOffset;
+					let end = (it.PointerToRawData + it.SizeOfRawData) as FileOffset;
+					return match self.image.get(start..end) {
+						Some(bytes) if bytes.len() >= min_size => Ok(bytes),
+						_ => if start + min_size > (it.VirtualAddress + it.VirtualSize) as usize { Err(Error::OOB) } else { Err(Error::ZeroFill) },
+					};
+				}
+				return Err(Error::ZeroFill);
+			}
+		}
+		Err(Error::OOB)
+	}
 }
 
 impl<'a> Pe<'a> for PeFile<'a> {
 	fn image(&self) -> &'a [u8] {
 		self.image
 	}
-	fn slice_rva(&self, rva: Rva, size: usize, align: usize) -> Result<&'a [u8]> {
+	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
 		if rva == 0 {
 			Err(Error::Null)
 		}
-		else if rva as usize & (align - 1) != 0 {
+		else if rva as FileOffset & (align - 1) != 0 {
 			Err(Error::Misalign)
 		}
 		else {
-			// Can't reuse `self.rva_to_file_offset` because it doesn't return the size of the section
-			for it in self.section_headers() {
-				if rva >= it.VirtualAddress && rva < (it.VirtualAddress + it.VirtualSize) {
-					if rva < (it.VirtualAddress + it.SizeOfRawData) {
-						let start = (rva - it.VirtualAddress + it.PointerToRawData) as FileOffset;
-						let end = (it.PointerToRawData + it.SizeOfRawData) as FileOffset;
-						return match self.image.get(start..end) {
-							Some(bytes) if bytes.len() >= size => Ok(bytes),
-							_ => if start + size > (it.VirtualAddress + it.VirtualSize) as usize { Err(Error::OOB) } else { Err(Error::ZeroFill) },
-						};
-					}
-					return Err(Error::ZeroFill);
-				}
-			}
+			self.find_section(rva, min_size)
+		}
+	}
+	fn read(&self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
+		let (image_base, size_of_image) = {
+			let optional_header = self.optional_header();
+			(optional_header.ImageBase, optional_header.SizeOfImage)
+		};
+		if va == 0 {
+			Err(Error::Null)
+		}
+		else if va < image_base || va - image_base > size_of_image as Va {
 			Err(Error::OOB)
+		}
+		else {
+			let rva = (va - image_base) as Rva;
+			if rva as FileOffset & (align - 1) != 0 {
+				Err(Error::Misalign)
+			}
+			else {
+				self.find_section(rva, min_size)
+			}
 		}
 	}
 }

--- a/src/pe64/imports.rs
+++ b/src/pe64/imports.rs
@@ -112,7 +112,7 @@ impl<'a, P: Pe<'a> + Copy> Desc<'a, P> {
 	}
 	/// Gets the name of the DLL imported from.
 	pub fn dll_name(&self) -> Result<&'a CStr> {
-		self.pe.derva_c_str(self.image.Name)
+		self.pe.derva_str(self.image.Name)
 	}
 	/// Gets the import address table.
 	///
@@ -144,7 +144,7 @@ fn import_from_va<'a, P: Pe<'a> + Copy>(pe: P, va: Va) -> Result<Import<'a>> {
 		// TODO! Validate that this really is an Rva in PE32+?
 		let rva = va as Rva;
 		let hint = pe.derva::<u16>(rva)?;
-		let name = pe.derva_c_str(rva + 2)?;
+		let name = pe.derva_str(rva + 2)?;
 		Ok(Import::ByName { hint: *hint as usize, name })
 	}
 	else {

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -56,10 +56,12 @@ pub trait Pe<'a> {
 
 	/// Converts an `Rva` to `FileOffset`.
 	///
-	/// Returns [`Err(ZeroFill)`](../enum.Error.html#variant.ZeroFill) if the rva points to the part of a section zero filled.
-	/// This happens when the size of raw data is shorter than the virtual size. Windows fills the remaining of the section with zeroes.
+	/// # Errors
 	///
-	/// Returns [`Err(OOB)`](../enum.Error.html#variant.OOB) if the rva does not point within any section. This includes the headers.
+	/// * [`Err(ZeroFill)`](../enum.Error.html#variant.ZeroFill) if the rva points to the part of a section zero filled.
+	///   This happens when the size of raw data is shorter than the virtual size. Windows fills the remaining of the section with zeroes.
+	///
+	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the rva does not point within any section. This includes the headers.
 	fn rva_to_file_offset(self, rva: Rva) -> Result<FileOffset> where Self: Copy {
 		for it in self.section_headers() {
 			if rva >= it.VirtualAddress && rva < (it.VirtualAddress + it.VirtualSize) {
@@ -73,8 +75,10 @@ pub trait Pe<'a> {
 	}
 	/// Converts a `FileOffset` to `Rva`.
 	///
-	/// Returns [`Err(OOB)`](../enum.Error.html#variant.OOB) if the file offset points within the headers or part of a section which isn't mapped.
-	/// This happens when the virtual size is shorter than the size of raw data.
+	/// # Errors
+	///
+	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the file offset points within the headers or part of a section which isn't mapped.
+	///   This happens when the virtual size is shorter than the size of raw data.
 	fn file_offset_to_rva(self, file_offset: FileOffset) -> Result<Rva> where Self: Copy {
 		for it in self.section_headers() {
 			if file_offset >= it.PointerToRawData as FileOffset && file_offset < (it.PointerToRawData as FileOffset + it.SizeOfRawData as FileOffset) {
@@ -89,33 +93,50 @@ pub trait Pe<'a> {
 
 	/// Converts from `Rva` to `Va`.
 	///
-	/// Returns [`Err(Null)`](../enum.Error.html#variant.Null) given a null rva or [`Err(OOB)`](../enum.Error.html#variant.OOB) if the rva is out of bounds.
+	/// # Errors
+	///
+	/// * [`Err(Null)`](../enum.Error.html#variant.Null) given a null rva.
+	///
+	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the rva is out of bounds.
 	fn rva_to_va(self, rva: Rva) -> Result<Va> where Self: Copy {
-		let (image_base, size_of_image) = {
-			let optional_header = self.optional_header();
-			(optional_header.ImageBase, optional_header.SizeOfImage)
-		};
-		if rva < size_of_image {
-			Ok(image_base + rva as Va)
+		if rva == BADRVA {
+			Err(Error::Null)
 		}
 		else {
-			Err(Error::OOB)
+			let (image_base, size_of_image) = {
+				let optional_header = self.optional_header();
+				(optional_header.ImageBase, optional_header.SizeOfImage)
+			};
+			if rva < size_of_image {
+				Ok(image_base + rva as Va)
+			}
+			else {
+				Err(Error::OOB)
+			}
 		}
 	}
 	/// Converts from `Va` to `Rva`.
 	///
-	/// Returns [`Err(Null)`](../enum.Error.html#variant.Null) given a null va or [`Err(OOB)`](../enum.Error.html#variant.OOB) if the va is out of bounds.
+	/// # Errors
+	///
+	/// * [`Err(Null)`](../enum.Error.html#variant.Null) given a null va.
+	///
+	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the va is out of bounds.
 	fn va_to_rva(self, va: Va) -> Result<Rva> where Self: Copy {
-		let (image_base, size_of_image) = {
-			let optional_header = self.optional_header();
-			(optional_header.ImageBase, optional_header.SizeOfImage)
-		};
-		let rva = va.checked_sub(image_base).ok_or(Error::OOB)?;
-		if rva < size_of_image as Va {
-			Ok(rva as Rva)
+		if va == BADVA {
+			Err(Error::Null)
 		}
 		else {
-			Err(Error::OOB)
+			let (image_base, size_of_image) = {
+				let optional_header = self.optional_header();
+				(optional_header.ImageBase, optional_header.SizeOfImage)
+			};
+			if va < image_base || va - image_base > size_of_image as Va {
+				Err(Error::OOB)
+			}
+			else {
+				Ok((va - image_base) as Rva)
+			}
 		}
 	}
 

--- a/src/pe64/scanner.rs
+++ b/src/pe64/scanner.rs
@@ -97,7 +97,7 @@ impl<'a, P: Pe<'a> + Copy> Scanner<P> {
 		for &atom in pat {
 			match atom {
 				pat::Atom::Byte(byte) => {
-					if Ok(&byte) != self.pe.derva(cursor) {
+					if Ok(byte) != self.pe.derva_copy(cursor) {
 						return None;
 					}
 					cursor += 1;
@@ -125,7 +125,7 @@ impl<'a, P: Pe<'a> + Copy> Scanner<P> {
 					cursor = cursor.wrapping_add(skip as Rva);
 				},
 				pat::Atom::Jump1 => {
-					if let Ok(&sbyte) = self.pe.derva::<i8>(cursor) {
+					if let Ok(sbyte) = self.pe.derva_copy::<i8>(cursor) {
 						cursor = cursor.wrapping_add(sbyte as Rva).wrapping_add(1);
 					}
 					else {
@@ -133,7 +133,7 @@ impl<'a, P: Pe<'a> + Copy> Scanner<P> {
 					}
 				},
 				pat::Atom::Jump4 => {
-					if let Ok(&sdword) = self.pe.derva::<i32>(cursor) {
+					if let Ok(sdword) = self.pe.derva_copy::<i32>(cursor) {
 						cursor = cursor.wrapping_add(sdword as Rva).wrapping_add(4);
 					}
 					else {
@@ -141,7 +141,7 @@ impl<'a, P: Pe<'a> + Copy> Scanner<P> {
 					}
 				},
 				pat::Atom::Ptr => {
-					cursor = match self.pe.derva(cursor).and_then(|&va| self.pe.va_to_rva(va)) {
+					cursor = match self.pe.derva_copy(cursor).and_then(|va| self.pe.va_to_rva(va)) {
 						Ok(cursor) => cursor,
 						Err(_) => return None,
 					};

--- a/src/pe64/tls.rs
+++ b/src/pe64/tls.rs
@@ -55,18 +55,15 @@ impl<'a, P: Pe<'a> + Copy> Tls<'a, P> {
 		if self.image.StartAddressOfRawData > self.image.EndAddressOfRawData {
 			return Err(Error::Corrupt);
 		}
-		let rva = self.pe.va_to_rva(self.image.StartAddressOfRawData)?;
 		// FIXME! truncation warning on 32bit...
 		let len = (self.image.EndAddressOfRawData - self.image.StartAddressOfRawData) as usize;
-		self.pe.derva_slice(rva, len)
+		self.pe.deref_slice(self.image.StartAddressOfRawData, len)
 	}
 	pub fn slot(&self) -> Result<&'a u32> {
-		let rva = self.pe.va_to_rva(self.image.AddressOfIndex)?;
-		self.pe.derva(rva)
+		self.pe.deref(self.image.AddressOfIndex)
 	}
 	pub fn callbacks(&self) -> Result<&'a [Va]> {
-		let rva = self.pe.va_to_rva(self.image.AddressOfCallBacks)?;
-		self.pe.derva_slice(rva, |&callback| callback == BADVA)
+		self.pe.deref_slice(self.image.AddressOfCallBacks, |&callback| callback == BADVA)
 	}
 }
 

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -59,7 +59,7 @@ impl<'a> Pe<'a> for PeView<'a> {
 	}
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
 		let start = rva as FileOffset;
-		if rva == 0 {
+		if rva == BADRVA {
 			Err(Error::Null)
 		}
 		else if start & (align - 1) != 0 {
@@ -77,7 +77,7 @@ impl<'a> Pe<'a> for PeView<'a> {
 			let optional_header = self.optional_header();
 			(optional_header.ImageBase, optional_header.SizeOfImage)
 		};
-		if va == 0 {
+		if va == BADVA {
 			Err(Error::Null)
 		}
 		else if va < image_base || va - image_base > size_of_image as Va {


### PR DESCRIPTION
New PE reading functions:

* `Pe::slice(rva, min_size, align)`
  Same as the old `slice_rva` function.

* `Pe::slice_bytes(rva)`
  Helper which calls `slice(rva, 0, 1)` convenience method.

* `Pe::read(va, min_size, align)`
  Same as the old `slice_rva` but now accepts a `Va` instead.
  This is avoids inlined `va_to_rva` and can now distinguish null `Va` from image base `Va`.

* `Pe::read_bytes(va)`
  Helper which calls `read(va, 0, 1)` convenience method.

Enforce alignment again in the functions returning a reference, can be turned off with the `unsafe_alignment` feature.

* `Pe::derva_copy` and `Pe::deref_copy` returning a copy of `T` which works with unaligned addresses.

* Renamed to `Pe::derva_str` and `Pe::deref_str` for overloading them in the future for other string types.

Includes refactoring the current code to support these breaking changes.