### PR TITLE
Minor internal resources refactor

### DIFF
--- a/src/pe64/resources.rs
+++ b/src/pe64/resources.rs
@@ -11,7 +11,7 @@ use pelite::pe64::{Pe, PeFile};
 use pelite::resources::FindError;
 
 # #[allow(dead_code)]
-fn example<'a>(file: PeFile<'a>) -> Result<Option<&'a [u8]>, FindError> {
+fn example<'a>(file: PeFile<'a>) -> Result<&'a [u8], FindError> {
 	// Access the resources
 	let resources = file.resources()?;
 
@@ -19,7 +19,7 @@ fn example<'a>(file: PeFile<'a>) -> Result<Option<&'a [u8]>, FindError> {
 	let entry = resources.find_data("/Manifest/2/1033")?;
 	let manifest = entry.data()?;
 
-	Ok(Some(manifest))
+	Ok(manifest)
 }
 ```
 */

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -88,7 +88,7 @@ impl<'a> Directory<'a> {
 	}
 	/// Gets the named entries in this directory.
 	///
-	/// Note that while it would be a violation of the format, there's no strict safety guarantee that these are only named entries.
+	/// Note that while it would be a violation of the format spec, there's no strict safety guarantee that these are only named entries.
 	pub fn named_entries(&self) -> Entries<'a> {
 		// Validated by constructor
 		let slice = unsafe {
@@ -101,7 +101,7 @@ impl<'a> Directory<'a> {
 	}
 	/// Gets the id entries in this directory.
 	///
-	/// Note that while it would be a violation of the format, there's no strict safety guarantee that these are only id entries.
+	/// Note that while it would be a violation of the format spec, there's no strict safety guarantee that these are only id entries.
 	pub fn id_entries(&self) -> Entries<'a> {
 		// Validated by the constructor
 		let slice = unsafe {


### PR DESCRIPTION
* Change example to remove unnecessary Option.
* Rename invalid utf8 path error enum name.
* Rename find_ to find_internal.
* Minor changes to documentation.