### PR TITLE
Deprecate pat::Match and related

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -366,6 +366,7 @@ fn parse_pat(pat: &str) -> Result<Pattern, PatError> {
 pub(crate) const MAX_SAVE: usize = 7;
 
 /// Pattern scan result.
+#[deprecated(note = "please use the functions `finds` and `finds_code` instead, which write directly to the user specified save array")]
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
 #[repr(C)]
 pub struct Match(pub u32, pub u32, pub u32, pub u32, pub u32, pub u32, pub u32);

--- a/src/pe64/scanner.rs
+++ b/src/pe64/scanner.rs
@@ -87,6 +87,7 @@ impl<'a, P: Pe<'a> + Copy> Scanner<P> {
 	/// Returns `None` if multiple matches are found to prevent subtle bugs where a pattern goes stale by not being unique any more.
 	///
 	/// Use `matches(pat, range).next()` if just the first match is desired.
+	#[deprecated(note = "please use `finds` instead")]
 	pub fn find(self, pat: &[pat::Atom], range: Range<Rva>) -> Option<pat::Match> {
 		let mut matches = self.matches(pat, range);
 		if let Some(found) = matches.next() {
@@ -103,6 +104,7 @@ impl<'a, P: Pe<'a> + Copy> Scanner<P> {
 	/// Finds the unique code match for the pattern.
 	///
 	/// Restricts the range to the code section. See [`find`](#find) for more information.
+	#[deprecated(note = "please use `finds_code` instead")]
 	pub fn find_code(self, pat: &[pat::Atom]) -> Option<pat::Match> {
 		let optional_header = self.pe.optional_header();
 		let range = optional_header.BaseOfCode..optional_header.BaseOfCode + optional_header.SizeOfCode;
@@ -398,6 +400,7 @@ impl<'a, 'u, P: Pe<'a> + Copy> Matches<'u, P> {
 		finder_section(self.scanner.pe, self.range.clone(), |it, slice| self.strategy(it, qsbuf, slice, save))
 	}
 }
+#[deprecated(note = "please use the functions `finds` and `finds_code` instead, which write directly to the user specified save array")]
 impl<'a, 'u, P: Pe<'a> + Copy> Iterator for Matches<'u, P> {
 	type Item = pat::Match;
 	fn next(&mut self) -> Option<pat::Match> {


### PR DESCRIPTION
This API was originally required to make the pattern scanner work with the `Iterator` trait (you cannot put the result of the iteration inside the iterator object, aka streaming iterator).

However this required that the returned object either had a fixed size (`pat::MAX_SAVE`) or a dynamically allocated Vec. So I went with `pat::Match`, a fixed length result object.

Since I've decided to drop the `Iterator` trait, the above workaround is no longer necessary and I would like to get rid of it.

Unfortunately `#[deprecated]` is very noisy so I expect this PR to remain until something changes, see rust-lang/rust#47219 and others.