### PR TITLE
Mutation Refactoring

### DIFF
--- a/src/pe32/mod.rs
+++ b/src/pe32/mod.rs
@@ -146,7 +146,7 @@ pub mod scanner;
 pub mod msvc;
 
 pub use self::image::{Va, Rva};
-pub use self::pe::{Align, Pe};
-pub use self::view::{PeView};
-pub use self::file::{PeFile};
+pub use self::pe::{Align, Pe, PeMut};
+pub use self::view::{PeView, PeViewMut};
+pub use self::file::{PeFile, PeFileMut};
 pub use self::ptr::Ptr;

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -8,7 +8,67 @@ use std::marker::PhantomData;
 use error::{Error, Result};
 
 use super::image::*;
-use super::pe::{Align, Pe, validate_headers};
+use super::pe::{Align, Pe, PeMut, validate_headers};
+
+//----------------------------------------------------------------
+
+fn range_to_slice<'a, P: Pe<'a> + Copy>(pe: P, rva: Rva, min_size: usize) -> Result<&'a [u8]> {
+	// Cannot reuse `self.rva_to_file_offset` because it doesn't return the size of the section
+	// FIXME! What to do about all the potential overflows?
+	for it in pe.section_headers() {
+		#[allow(non_snake_case)]
+		let VirtualEnd = it.VirtualAddress + cmp::max(it.VirtualSize, it.SizeOfRawData);
+		// Rva is contained within the virtual space of a section
+		if rva >= it.VirtualAddress && rva <= VirtualEnd {
+			let start = (rva - it.VirtualAddress + it.PointerToRawData) as usize;
+			let end = (it.PointerToRawData + it.SizeOfRawData) as usize;
+			return match pe.image().get(start..end) {
+				Some(bytes) if bytes.len() >= min_size => Ok(bytes),
+				// Identify the reason the slice fails
+				_ => Err(if rva + min_size as Rva > VirtualEnd { Error::OOB } else { Error::ZeroFill }),
+			};
+		}
+	}
+	Err(Error::OOB)
+}
+#[inline(never)]
+fn slice_impl<'a, P: Pe<'a> + Copy>(pe: P, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
+	debug_assert!(align != 0 && align & (align - 1) == 0);
+	if rva == BADRVA {
+		Err(Error::Null)
+	}
+	else if rva as usize & (align - 1) != 0 {
+		Err(Error::Misalign)
+	}
+	else {
+		range_to_slice(pe, rva, min_size)
+	}
+}
+#[inline(never)]
+fn read_impl<'a, P: Pe<'a> + Copy>(pe: P, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
+	debug_assert!(align != 0 && align & (align - 1) == 0);
+	let (image_base, size_of_image) = {
+		let optional_header = pe.optional_header();
+		(optional_header.ImageBase, optional_header.SizeOfImage)
+	};
+	if va == BADVA {
+		Err(Error::Null)
+	}
+	else if va < image_base || va - image_base > size_of_image as Va {
+		Err(Error::OOB)
+	}
+	else {
+		let rva = (va - image_base) as Rva;
+		if rva as usize & (align - 1) != 0 {
+			Err(Error::Misalign)
+		}
+		else {
+			range_to_slice(pe, rva, min_size)
+		}
+	}
+}
+
+//----------------------------------------------------------------
 
 /// View into an unmapped PE file.
 #[derive(Copy, Clone)]
@@ -24,67 +84,6 @@ impl<'a> PeFile<'a> {
 		let _ = validate_headers(image)?;
 		Ok(PeFile { image, _phantom: PhantomData })
 	}
-	/// Try to read the given bytes as an unmapped PE file.
-	///
-	/// Acquire unique lock on the image bytes allowing safe mutation.
-	pub fn from_bytes_mut<T: AsMut<[u8]> + ?Sized>(image: &'a mut T) -> Result<PeFile<'a>> {
-		Self::from_bytes(image.as_mut())
-	}
-	fn range_to_slice(&self, rva: Rva, min_size: usize) -> Result<&'a [u8]> {
-		// Cannot reuse `self.rva_to_file_offset` because it doesn't return the size of the section
-		// FIXME! What to do about all the potential overflows?
-		for it in self.section_headers() {
-			#[allow(non_snake_case)]
-			let VirtualEnd = it.VirtualAddress + cmp::max(it.VirtualSize, it.SizeOfRawData);
-			// Rva is contained within the virtual space of a section
-			if rva >= it.VirtualAddress && rva <= VirtualEnd {
-				let start = (rva - it.VirtualAddress + it.PointerToRawData) as usize;
-				let end = (it.PointerToRawData + it.SizeOfRawData) as usize;
-				return match self.image().get(start..end) {
-					Some(bytes) if bytes.len() >= min_size => Ok(bytes),
-					// Identify the reason the slice fails
-					_ => Err(if rva + min_size as Rva > VirtualEnd { Error::OOB } else { Error::ZeroFill }),
-				};
-			}
-		}
-		Err(Error::OOB)
-	}
-	#[inline(never)]
-	fn slice_impl(self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		debug_assert!(align != 0 && align & (align - 1) == 0);
-		if rva == BADRVA {
-			Err(Error::Null)
-		}
-		else if rva as usize & (align - 1) != 0 {
-			Err(Error::Misalign)
-		}
-		else {
-			self.range_to_slice(rva, min_size)
-		}
-	}
-	#[inline(never)]
-	fn read_impl(self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		debug_assert!(align != 0 && align & (align - 1) == 0);
-		let (image_base, size_of_image) = {
-			let optional_header = self.optional_header();
-			(optional_header.ImageBase, optional_header.SizeOfImage)
-		};
-		if va == BADVA {
-			Err(Error::Null)
-		}
-		else if va < image_base || va - image_base > size_of_image as Va {
-			Err(Error::OOB)
-		}
-		else {
-			let rva = (va - image_base) as Rva;
-			if rva as usize & (align - 1) != 0 {
-				Err(Error::Misalign)
-			}
-			else {
-				self.range_to_slice(rva, min_size)
-			}
-		}
-	}
 }
 
 unsafe impl<'a> Pe<'a> for PeFile<'a> {
@@ -95,12 +94,46 @@ unsafe impl<'a> Pe<'a> for PeFile<'a> {
 		Align::File
 	}
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		self.slice_impl(rva, min_size, align)
+		slice_impl(*self, rva, min_size, align)
 	}
 	fn read(&self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		self.read_impl(va, min_size, align)
+		read_impl(*self, va, min_size, align)
 	}
 }
+
+//----------------------------------------------------------------
+
+#[derive(Copy, Clone)]
+pub struct PeFileMut<'a> {
+	image: *mut [u8],
+	_phantom: PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> PeFileMut<'a> {
+	/// Try to read the given bytes as an unmapped PE file.
+	pub fn from_bytes<T: AsMut<[u8]> + ?Sized>(image: &'a mut T) -> Result<PeFileMut<'a>> {
+		let image = image.as_mut();
+		let _ = validate_headers(image)?;
+		Ok(PeFileMut { image, _phantom: PhantomData })
+	}
+}
+
+unsafe impl<'a> Pe<'a> for PeFileMut<'a> {
+	fn image(&self) -> &'a [u8] {
+		unsafe { &*self.image }
+	}
+	fn align(&self) -> Align {
+		Align::File
+	}
+	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
+		slice_impl(*self, rva, min_size, align)
+	}
+	fn read(&self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
+		read_impl(*self, va, min_size, align)
+	}
+}
+
+unsafe impl<'a> PeMut<'a> for PeFileMut<'a> {}
 
 //----------------------------------------------------------------
 

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -24,6 +24,12 @@ impl<'a> PeFile<'a> {
 		let _ = validate_headers(image)?;
 		Ok(PeFile { image, _phantom: PhantomData })
 	}
+	/// Try to read the given bytes as an unmapped PE file.
+	///
+	/// Acquire unique lock on the image bytes allowing safe mutation.
+	pub fn from_bytes_mut<T: AsMut<[u8]> + ?Sized>(image: &'a mut T) -> Result<PeFile<'a>> {
+		Self::from_bytes(image.as_mut())
+	}
 	fn range_to_slice(&self, rva: Rva, min_size: usize) -> Result<&'a [u8]> {
 		// Cannot reuse `self.rva_to_file_offset` because it doesn't return the size of the section
 		// FIXME! What to do about all the potential overflows?

--- a/src/pe64/mod.rs
+++ b/src/pe64/mod.rs
@@ -131,7 +131,7 @@ mod ptr;
 pub mod scanner;
 
 pub use self::image::{Va, Rva};
-pub use self::pe::{Align, Pe};
-pub use self::view::{PeView};
-pub use self::file::{PeFile};
+pub use self::pe::{Align, Pe, PeMut};
+pub use self::view::{PeView, PeViewMut};
+pub use self::file::{PeFile, PeFileMut};
 pub use self::ptr::Ptr;

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -419,6 +419,12 @@ unsafe impl<'s, 'a, P: Pe<'a> + ?Sized> Pe<'a> for &'s P {
 
 //----------------------------------------------------------------
 
+pub unsafe trait PeMut<'a>: Pe<'a> {}
+
+unsafe impl<'s, 'a, P: PeMut<'a> + ?Sized> PeMut<'a> for &'s P {}
+
+//----------------------------------------------------------------
+
 pub(crate) struct VH {
 	pub image_base: Va,
 	pub size_of_image: u32,

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -38,6 +38,12 @@ impl<'a> PeView<'a> {
 		}
 		Ok(PeView { image, _phantom: PhantomData })
 	}
+	/// Try to read the given bytes as a mapped PE image.
+	///
+	/// Acquire unique lock on the image bytes allowing safe mutation.
+	pub fn from_bytes_mut<T: AsMut<[u8]> + ?Sized>(image: &'a mut T) -> Result<PeView<'a>> {
+		Self::from_bytes(image.as_mut())
+	}
 	/// Creates a new instance of `PeView` of a mapped image.
 	///
 	/// # Safety

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -8,7 +8,51 @@ use std::marker::PhantomData;
 use error::{Error, Result};
 
 use super::image::*;
-use super::pe::{Align, Pe, validate_headers};
+use super::pe::{Align, Pe, PeMut, validate_headers};
+
+fn slice_impl<'a, P: Pe<'a> + Copy>(pe: P, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
+	debug_assert!(align != 0 && align & (align - 1) == 0);
+	let start = rva as usize;
+	if rva == BADRVA {
+		Err(Error::Null)
+	}
+	else if start & (align - 1) != 0 {
+		Err(Error::Misalign)
+	}
+	else {
+		match pe.image().get(start..) {
+			Some(bytes) if bytes.len() >= min_size => Ok(bytes),
+			_ => Err(Error::OOB),
+		}
+	}
+}
+fn read_impl<'a, P: Pe<'a> + Copy>(pe: P, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
+	debug_assert!(align != 0 && align & (align - 1) == 0);
+	let (image_base, size_of_image) = {
+		let optional_header = pe.optional_header();
+		(optional_header.ImageBase, optional_header.SizeOfImage)
+	};
+	if va == BADVA {
+		Err(Error::Null)
+	}
+	else if va < image_base || va - image_base > size_of_image as Va {
+		Err(Error::OOB)
+	}
+	else {
+		let start = (va - image_base) as usize;
+		if start & (align - 1) != 0 {
+			Err(Error::Misalign)
+		}
+		else {
+			match pe.image().get(start..) {
+				Some(bytes) if bytes.len() >= min_size => Ok(bytes),
+				_ => Err(Error::OOB),
+			}
+		}
+	}
+}
+
+//----------------------------------------------------------------
 
 /// View into a mapped PE image.
 #[derive(Copy, Clone)]
@@ -38,12 +82,6 @@ impl<'a> PeView<'a> {
 		}
 		Ok(PeView { image, _phantom: PhantomData })
 	}
-	/// Try to read the given bytes as a mapped PE image.
-	///
-	/// Acquire unique lock on the image bytes allowing safe mutation.
-	pub fn from_bytes_mut<T: AsMut<[u8]> + ?Sized>(image: &'a mut T) -> Result<PeView<'a>> {
-		Self::from_bytes(image.as_mut())
-	}
 	/// Creates a new instance of `PeView` of a mapped image.
 	///
 	/// # Safety
@@ -61,47 +99,6 @@ impl<'a> PeView<'a> {
 			_phantom: PhantomData,
 		}
 	}
-	fn slice_impl(self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		debug_assert!(align != 0 && align & (align - 1) == 0);
-		let start = rva as usize;
-		if rva == BADRVA {
-			Err(Error::Null)
-		}
-		else if start & (align - 1) != 0 {
-			Err(Error::Misalign)
-		}
-		else {
-			match self.image().get(start..) {
-				Some(bytes) if bytes.len() >= min_size => Ok(bytes),
-				_ => Err(Error::OOB),
-			}
-		}
-	}
-	fn read_impl(self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		debug_assert!(align != 0 && align & (align - 1) == 0);
-		let (image_base, size_of_image) = {
-			let optional_header = self.optional_header();
-			(optional_header.ImageBase, optional_header.SizeOfImage)
-		};
-		if va == BADVA {
-			Err(Error::Null)
-		}
-		else if va < image_base || va - image_base > size_of_image as Va {
-			Err(Error::OOB)
-		}
-		else {
-			let start = (va - image_base) as usize;
-			if start & (align - 1) != 0 {
-				Err(Error::Misalign)
-			}
-			else {
-				match self.image().get(start..) {
-					Some(bytes) if bytes.len() >= min_size => Ok(bytes),
-					_ => Err(Error::OOB),
-				}
-			}
-		}
-	}
 }
 
 unsafe impl<'a> Pe<'a> for PeView<'a> {
@@ -112,12 +109,50 @@ unsafe impl<'a> Pe<'a> for PeView<'a> {
 		Align::Section
 	}
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		self.slice_impl(rva, min_size, align)
+		slice_impl(*self, rva, min_size, align)
 	}
 	fn read(&self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		self.read_impl(va, min_size, align)
+		read_impl(*self, va, min_size, align)
 	}
 }
+
+//----------------------------------------------------------------
+
+#[derive(Copy, Clone)]
+pub struct PeViewMut<'a> {
+	image: *mut [u8],
+	_phantom: PhantomData<&'a mut [u8]>,
+}
+impl<'a> PeViewMut<'a> {
+	/// Try to read the given bytes as a mapped PE image.
+	///
+	/// Acquire unique lock on the image bytes allowing safe mutation.
+	pub fn from_bytes_mut<T: AsMut<[u8]> + ?Sized>(image: &'a mut T) -> Result<PeViewMut<'a>> {
+		let image = image.as_mut();
+		let info = validate_headers(image)?;
+		// Sanity check, this values should match.
+		// If they don't, that's not a problem per sé as it would be caught later.
+		if info.size_of_image as usize != image.len() {
+			return Err(Error::Insanity);
+		}
+		Ok(PeViewMut { image, _phantom: PhantomData })
+	}
+}
+unsafe impl<'a> Pe<'a> for PeViewMut<'a> {
+	fn image(&self) -> &'a [u8] {
+		unsafe { &*self.image }
+	}
+	fn align(&self) -> Align {
+		Align::Section
+	}
+	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
+		slice_impl(*self, rva, min_size, align)
+	}
+	fn read(&self, va: Va, min_size: usize, align: usize) -> Result<&'a [u8]> {
+		read_impl(*self, va, min_size, align)
+	}
+}
+unsafe impl<'a> PeMut<'a> for PeViewMut<'a> {}
 
 //----------------------------------------------------------------
 

--- a/src/util/pod.rs
+++ b/src/util/pod.rs
@@ -2,6 +2,8 @@
 Podness.
 */
 
+use std::cell;
+
 /// Defines types which can be safely `transmute`d from any bit pattern.
 ///
 /// Types which need to be read from PE files should implement this.
@@ -25,6 +27,9 @@ unsafe impl Pod for u64 {}
 
 unsafe impl Pod for f32 {}
 unsafe impl Pod for f64 {}
+
+unsafe impl<T: Pod> Pod for cell::UnsafeCell<T> {}
+unsafe impl<T: Pod> Pod for cell::Cell<T> {}
 
 macro_rules! impl_pod_array {
 	($n:tt $($tail:tt)+) => {


### PR DESCRIPTION
Provide an API to allow mutation of the underlying PE image.

* [ ] Update `PeFile` and `PeView` to store the image as a `*const [u8]`

Potential questions:

* The constructors should probably be adjusted to take unique references to the underlying memory. This is a major breaking API change.
* All the PE modules (imports, exports, resources, etc...) should hold raw pointers to image structs. This can probably be done with `*const T` as it is legal to modify `T` behind a const pointer. Verify this.
* Can this API change be achieved while maintaining a constructor for `&'a [u8]` for `PeFile` and `PeView`?
* How should the mutation API look, probably via returning `*mut T` because it cannot guarantee no aliasing.
* More to come as I think of it.