### PR TITLE
Fix off-by-one in PeFile and drop FileOffset type

### DIFF
--- a/src/pe32/image.rs
+++ b/src/pe32/image.rs
@@ -16,8 +16,6 @@ pub type IMAGE_TLS_DIRECTORY = IMAGE_TLS_DIRECTORY32;
 pub type Rva = u32;
 /// Virtual address type, absolute address as known by the image. Not always the same as a pointer.
 pub type Va = u32;
-/// FileOffset type, when dealing with file offsets.
-pub type FileOffset = usize;
 
 /// Invalid Rva value.
 pub const BADRVA: Rva = 0;

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -22,7 +22,7 @@ impl<'a> PeFile<'a> {
 		let _ = validate_headers(image)?;
 		Ok(PeFile { image })
 	}
-	fn section_get(&self, rva: Rva, min_size: usize) -> Result<&'a [u8]> {
+	fn range_to_slice(&self, rva: Rva, min_size: usize) -> Result<&'a [u8]> {
 		// Cannot reuse `self.rva_to_file_offset` because it doesn't return the size of the section
 		// FIXME! What to do about all the potential overflows?
 		for it in self.section_headers() {
@@ -56,7 +56,7 @@ unsafe impl<'a> Pe<'a> for PeFile<'a> {
 			Err(Error::Misalign)
 		}
 		else {
-			self.section_get(rva, min_size)
+			self.range_to_slice(rva, min_size)
 		}
 	}
 	#[inline(never)]
@@ -77,7 +77,7 @@ unsafe impl<'a> Pe<'a> for PeFile<'a> {
 				Err(Error::Misalign)
 			}
 			else {
-				self.section_get(rva, min_size)
+				self.range_to_slice(rva, min_size)
 			}
 		}
 	}

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -35,12 +35,7 @@ impl<'a> PeFile<'a> {
 				return match self.image.get(start..end) {
 					Some(bytes) if bytes.len() >= min_size => Ok(bytes),
 					// Identify the reason the slice fails
-					_ => if start + min_size > VirtualEnd as usize {
-						Err(Error::OOB)
-					}
-					else {
-						Err(Error::ZeroFill)
-					},
+					_ => Err(if rva + min_size as Rva > VirtualEnd { Error::OOB } else { Error::ZeroFill }),
 				};
 			}
 		}

--- a/src/pe64/image.rs
+++ b/src/pe64/image.rs
@@ -16,8 +16,6 @@ pub type IMAGE_TLS_DIRECTORY = IMAGE_TLS_DIRECTORY64;
 pub type Rva = u32;
 /// Virtual address type, absolute address as known by the image. Not always the same as a pointer.
 pub type Va = u64;
-/// FileOffset type, when dealing with file offsets.
-pub type FileOffset = usize;
 
 /// Invalid Rva value.
 pub const BADRVA: Rva = 0;

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -55,7 +55,7 @@ pub unsafe trait Pe<'a> {
 
 	//----------------------------------------------------------------
 
-	/// Converts an `Rva` to `FileOffset`.
+	/// Converts an `Rva` to file offset.
 	///
 	/// # Errors
 	///
@@ -63,27 +63,27 @@ pub unsafe trait Pe<'a> {
 	///   This happens when the size of raw data is shorter than the virtual size. Windows fills the remaining of the section with zeroes.
 	///
 	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the rva does not point within any section. This includes the headers.
-	fn rva_to_file_offset(self, rva: Rva) -> Result<FileOffset> where Self: Copy {
+	fn rva_to_file_offset(self, rva: Rva) -> Result<usize> where Self: Copy {
 		for it in self.section_headers() {
 			if rva >= it.VirtualAddress && rva < (it.VirtualAddress + it.VirtualSize) {
 				if rva < (it.VirtualAddress + it.SizeOfRawData) {
-					return Ok((rva - it.VirtualAddress + it.PointerToRawData) as FileOffset);
+					return Ok((rva - it.VirtualAddress + it.PointerToRawData) as usize);
 				}
 				return Err(Error::ZeroFill);
 			}
 		}
 		Err(Error::OOB)
 	}
-	/// Converts a `FileOffset` to `Rva`.
+	/// Converts a file offset to `Rva`.
 	///
 	/// # Errors
 	///
 	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the file offset points within the headers or part of a section which isn't mapped.
 	///   This happens when the virtual size is shorter than the size of raw data.
-	fn file_offset_to_rva(self, file_offset: FileOffset) -> Result<Rva> where Self: Copy {
+	fn file_offset_to_rva(self, file_offset: usize) -> Result<Rva> where Self: Copy {
 		for it in self.section_headers() {
-			if file_offset >= it.PointerToRawData as FileOffset && file_offset < (it.PointerToRawData as FileOffset + it.SizeOfRawData as FileOffset) {
-				if file_offset < (it.PointerToRawData as FileOffset + it.VirtualSize as FileOffset) {
+			if file_offset >= it.PointerToRawData as usize && file_offset < (it.PointerToRawData as usize + it.SizeOfRawData as usize) {
+				if file_offset < (it.PointerToRawData as usize + it.VirtualSize as usize) {
 					return Ok(file_offset as Rva - it.PointerToRawData + it.VirtualAddress);
 				}
 				return Err(Error::OOB);

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -2,7 +2,7 @@
 Abstract over mapped images and file binaries.
 */
 
-use std::{mem, ptr, slice};
+use std::{cmp, mem, ptr, slice};
 
 use error::{Error, Result};
 use util::{CStr, Pod, SliceLen};
@@ -65,7 +65,9 @@ pub unsafe trait Pe<'a> {
 	/// * [`Err(OOB)`](../enum.Error.html#variant.OOB) if the rva does not point within any section. This includes the headers.
 	fn rva_to_file_offset(self, rva: Rva) -> Result<usize> where Self: Copy {
 		for it in self.section_headers() {
-			if rva >= it.VirtualAddress && rva < (it.VirtualAddress + it.VirtualSize) {
+			#[allow(non_snake_case)]
+			let VirtualEnd = it.VirtualAddress + cmp::max(it.VirtualSize, it.SizeOfRawData);
+			if rva >= it.VirtualAddress && rva < VirtualEnd {
 				if rva < (it.VirtualAddress + it.SizeOfRawData) {
 					return Ok((rva - it.VirtualAddress + it.PointerToRawData) as usize);
 				}

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -59,7 +59,7 @@ unsafe impl<'a> Pe<'a> for PeView<'a> {
 		self.image
 	}
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
-		let start = rva as FileOffset;
+		let start = rva as usize;
 		if rva == BADRVA {
 			Err(Error::Null)
 		}
@@ -85,7 +85,7 @@ unsafe impl<'a> Pe<'a> for PeView<'a> {
 			Err(Error::OOB)
 		}
 		else {
-			let start = (va - image_base) as FileOffset;
+			let start = (va - image_base) as usize;
 			if start & (align - 1) != 0 {
 				Err(Error::Misalign)
 			}

--- a/tests/demo64.rs
+++ b/tests/demo64.rs
@@ -29,6 +29,11 @@ fn slice_edges() {
 	assert_edges(0x7000, 0x0200);
 	assert_edges(0x8000, 0x4200);
 	assert_edges(0xD000, 0x0200);
+
+	println!("----------------------------------------------------------------");
+
+	assert_eq!(file.slice(0x5000, 0x710, 1), Err(pelite::Error::ZeroFill));
+	assert_eq!(file.slice(0x5000, 0x800, 1), Err(pelite::Error::OOB));
 }
 
 //----------------------------------------------------------------

--- a/tests/demo64.rs
+++ b/tests/demo64.rs
@@ -30,10 +30,8 @@ fn slice_edges() {
 	assert_edges(0x8000, 0x4200);
 	assert_edges(0xD000, 0x0200);
 
-	println!("----------------------------------------------------------------");
-
 	assert_eq!(file.slice(0x5000, 0x710, 1), Err(pelite::Error::ZeroFill));
-	assert_eq!(file.slice(0x5000, 0x800, 1), Err(pelite::Error::OOB));
+	assert_eq!(file.slice(0x5000, 0x711, 1), Err(pelite::Error::OOB));
 }
 
 //----------------------------------------------------------------

--- a/tests/demo64.rs
+++ b/tests/demo64.rs
@@ -1,13 +1,35 @@
 extern crate pelite;
 
 use pelite::FileMap;
-use pelite::pe64::{Pe, PeFile};
+use pelite::pe64::{Rva, Pe, PeFile};
 use pelite::pe64::exports::Export;
 use pelite::pe64::imports::Import;
 use pelite::pe64::debug::Info;
 use pelite::util::CStr;
 
 const FILE_NAME: &str = "demo/Demo64.dll";
+
+//----------------------------------------------------------------
+
+#[test]
+fn slice_edges() {
+	let file_map = FileMap::open(FILE_NAME).unwrap();
+	let file = PeFile::from_bytes(&file_map).unwrap();
+
+	let assert_edges = |rva: Rva, len: usize| {
+		assert_eq!(file.slice_bytes(rva).unwrap().len(), len);
+		assert_eq!(file.slice_bytes(rva + len as Rva).unwrap().len(), 0);
+		assert_eq!(file.slice(rva, len, 1).unwrap().len(), len);
+	};
+
+	assert_edges(0x1000, 0x1200);
+	assert_edges(0x3000, 0x1200);
+	assert_edges(0x5000, 0x0200);
+	assert_edges(0x6000, 0x0200);
+	assert_edges(0x7000, 0x0200);
+	assert_edges(0x8000, 0x4200);
+	assert_edges(0xD000, 0x0200);
+}
 
 //----------------------------------------------------------------
 


### PR DESCRIPTION
Slice to one byte past the end of a section with length of zero should be allowed.