### PR TITLE
Query alignment

### DIFF
--- a/src/pe32/mod.rs
+++ b/src/pe32/mod.rs
@@ -175,7 +175,7 @@ pub mod scanner;
 pub mod msvc;
 
 pub use self::image::{Va, Rva};
-pub use self::pe::{Pe};
+pub use self::pe::{Align, Pe};
 pub use self::view::{PeView};
 pub use self::file::{PeFile};
 pub use self::ptr::Ptr;

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -7,7 +7,7 @@ use std::cmp;
 use error::{Error, Result};
 
 use super::image::*;
-use super::pe::{Pe, validate_headers};
+use super::pe::{Align, Pe, validate_headers};
 
 /// View into an unmapped PE file.
 #[derive(Copy, Clone)]
@@ -46,6 +46,9 @@ impl<'a> PeFile<'a> {
 unsafe impl<'a> Pe<'a> for PeFile<'a> {
 	fn image(&self) -> &'a [u8] {
 		self.image
+	}
+	fn align(&self) -> Align {
+		Align::File
 	}
 	#[inline(never)]
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {

--- a/src/pe64/mod.rs
+++ b/src/pe64/mod.rs
@@ -160,7 +160,7 @@ mod ptr;
 pub mod scanner;
 
 pub use self::image::{Va, Rva};
-pub use self::pe::{Pe};
+pub use self::pe::{Align, Pe};
 pub use self::view::{PeView};
 pub use self::file::{PeFile};
 pub use self::ptr::Ptr;

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -12,9 +12,22 @@ use super::ptr::Ptr;
 
 //----------------------------------------------------------------
 
+/// The specific alignment used by the view.
+///
+/// See [the module-level documentation](index.html#getting-started) for more information.
+pub enum Align {
+	/// The view uses file alignment, typically 512 bytes.
+	File,
+	/// The view uses section alignment, typically 4 KiB.
+	Section,
+}
+
 pub unsafe trait Pe<'a> {
 	/// Returns the image as a byte slice.
 	fn image(&self) -> &'a [u8];
+
+	/// Returns whether this image uses file alignment or section alignment.
+	fn align(&self) -> Align;
 
 	/// Returns the DOS header.
 	fn dos_header(self) -> &'a IMAGE_DOS_HEADER where Self: Copy {
@@ -344,6 +357,9 @@ pub unsafe trait Pe<'a> {
 unsafe impl<'s, 'a, P: Pe<'a> + ?Sized> Pe<'a> for &'s P {
 	fn image(&self) -> &'a [u8] {
 		P::image(*self)
+	}
+	fn align(&self) -> Align {
+		P::align(*self)
 	}
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
 		P::slice(*self, rva, min_size, align)

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -336,21 +336,6 @@ pub unsafe trait Pe<'a> {
 	fn scanner(self) -> super::scanner::Scanner<Self> where Self: Copy {
 		super::scanner::Scanner::new(self)
 	}
-
-	#[doc(hidden)]
-	fn finder_image<F>(&self, mut f: F) -> bool where Self: Sized, F: FnMut(Rva, &'a [u8]) -> bool {
-		let image = self.image();
-		for section in self.section_headers() {
-			let start = section.PointerToRawData as usize;
-			let end = section.PointerToRawData as usize + section.SizeOfRawData as usize;
-			if let Some(slice) = image.get(start..end) {
-				if f(section.VirtualAddress, slice) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
 }
 
 // Make `&Pe<'a>` trait objects work seamlessly.

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -102,10 +102,6 @@ unsafe impl<'a> Pe<'a> for PeView<'a> {
 			}
 		}
 	}
-	#[doc(hidden)]
-	fn finder_image<F>(&self, mut f: F) -> bool where F: FnMut(Rva, &'a [u8]) -> bool {
-		f(0, self.image)
-	}
 }
 
 //----------------------------------------------------------------

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -7,7 +7,7 @@ use std::slice;
 use error::{Error, Result};
 
 use super::image::*;
-use super::pe::{Pe, validate_headers};
+use super::pe::{Align, Pe, validate_headers};
 
 /// View into a mapped PE image.
 #[derive(Copy, Clone)]
@@ -57,6 +57,9 @@ impl<'a> PeView<'a> {
 unsafe impl<'a> Pe<'a> for PeView<'a> {
 	fn image(&self) -> &'a [u8] {
 		self.image
+	}
+	fn align(&self) -> Align {
+		Align::Section
 	}
 	fn slice(&self, rva: Rva, min_size: usize, align: usize) -> Result<&'a [u8]> {
 		debug_assert!(align != 0 && align & (align - 1) == 0);


### PR DESCRIPTION
Add a method to `Pe` to query if it uses file or section alignment.

This lets the scanner avoid having to add custom logic to `Pe` so it can optimize its logic based on which alignment is used.

I'm sure it'll be useful elsewhere too.