### PR TITLE
Revamp base relocations

### DIFF
--- a/src/bin/msrtti.rs
+++ b/src/bin/msrtti.rs
@@ -59,7 +59,7 @@ fn main() {
 	// I'm sure this can all be done with more heuristics without requiring all the above informatoin
 
 	// Collect all xrefs from rdata to text
-	let mut vrefs: Vec<Rva> = base_relocs.into_iter().flat_map(|relocs| relocs).filter_map(|rva| {
+	let mut vrefs: Vec<Rva> = base_relocs.into_iter().filter_map(|rva| {
 		// Look for xrefs from rdata (the virtual function pointers)
 		if rva < rdata.VirtualAddress || rva >= (rdata.VirtualAddress + rdata.VirtualSize) {
 			return None;
@@ -79,7 +79,7 @@ fn main() {
 
 	// The vtables themselves will be referenced from other places (such as the RTTI data, constructors and dynamic_casts)
 	// By collecting all xrefs to the previously collected pointers, we can find the start of the vtable
-	let mut xrefs: Vec<usize> = base_relocs.into_iter().flat_map(|relocs| relocs).filter_map(|rva| {
+	let mut xrefs: Vec<usize> = base_relocs.into_iter().filter_map(|rva| {
 		// Read the pointer being relocated
 		let target_va = file.derva_copy(rva).expect(&format!("msrtti: corrupt reloc at {:08X}", rva));
 		let target_rva = file.va_to_rva(target_va).expect(&format!("msrtti: corrupt xref at {:08X}", rva));

--- a/src/pe64/base_relocs.rs
+++ b/src/pe64/base_relocs.rs
@@ -12,15 +12,15 @@ fn example(file: PeFile) -> pelite::Result<()> {
 	// Access the base relocations
 	let base_relocs = file.base_relocs()?;
 
-	// Iterate over the flattened list of relocations
-	for rva in base_relocs.into_iter().flat_map(|relocs| relocs) {}
+	// Iterate over the rva which need relocation
+	for rva in base_relocs {}
 
 	Ok(())
 }
 ```
 */
 
-use std::{fmt, mem, slice};
+use std::{fmt, iter, mem, slice};
 
 use error::{Error, Result};
 
@@ -29,6 +29,7 @@ use super::Pe;
 
 //----------------------------------------------------------------
 
+/// Base Relocations Directory.
 #[derive(Copy, Clone)]
 pub struct BaseRelocs<'a, P> {
 	pe: P,
@@ -39,7 +40,8 @@ impl<'a, P: Pe<'a> + Copy> BaseRelocs<'a, P> {
 		let datadir = pe.data_directory().get(IMAGE_DIRECTORY_ENTRY_BASERELOC).ok_or(Error::OOB)?;
 		let relocs = pe.derva_slice(datadir.VirtualAddress, datadir.Size as usize)?;
 		// Validate the relocations...
-		// This better not contain any bugs.
+		// All unsafe blocks in this module rely on this being correct, no pressure there.
+		// FIXME! I know this broken in subtle ways, please fix it.
 		let mut it = relocs;
 		while it.len() > 0 {
 			if it.len() < mem::size_of::<IMAGE_BASE_RELOCATION>() {
@@ -53,15 +55,26 @@ impl<'a, P: Pe<'a> + Copy> BaseRelocs<'a, P> {
 		}
 		Ok(BaseRelocs { pe, relocs })
 	}
+	/// Gets the PE instance.
 	pub fn pe(&self) -> P {
 		self.pe
 	}
+	/// Iterates over the base relocation blocks.
+	pub fn iter_blocks(&self) -> IterBlocks<'a, P> {
+		IterBlocks {
+			pe: self.pe,
+			iter: self.relocs.iter()
+		}
+	}
 }
 impl<'a, P: Pe<'a> + Copy> IntoIterator for BaseRelocs<'a, P> {
-	type Item = Block<'a, P>;
-	type IntoIter = Iter<'a, P>;
-	fn into_iter(self) -> Iter<'a, P> {
-		Iter { pe: self.pe, iter: self.relocs.iter() }
+	type Item = Rva;
+	type IntoIter = Iter<'a>;
+	fn into_iter(self) -> Iter<'a> {
+		Iter {
+			iter: self.relocs.iter(),
+			offset: mem::size_of::<IMAGE_BASE_RELOCATION>(),
+		}
 	}
 }
 impl<'a, P: Pe<'a> + Copy> fmt::Debug for BaseRelocs<'a, P> {
@@ -72,17 +85,90 @@ impl<'a, P: Pe<'a> + Copy> fmt::Debug for BaseRelocs<'a, P> {
 
 //----------------------------------------------------------------
 
-/// Iterator over the base relocations.
+/// Iterator over the rva which need relocation in the image.
+pub struct Iter<'a> {
+	iter: slice::Iter<'a, u8>,
+	offset: usize,
+}
+impl<'a> Iterator for Iter<'a> {
+	type Item = Rva;
+	fn next(&mut self) -> Option<Rva> {
+		while self.iter.len() != 0 {
+			// Safety checked by new
+			unsafe {
+				let bytes = self.iter.as_slice();
+				let image = &*(bytes.as_ptr() as *const IMAGE_BASE_RELOCATION);
+				let word = *(bytes.as_ptr().offset(self.offset as isize) as *const u16);
+
+				let next_offset = self.offset + 2;
+				self.offset = if next_offset >= image.SizeOfBlock as usize {
+					self.iter = bytes.get_unchecked(image.SizeOfBlock as usize..).iter();
+					mem::size_of::<IMAGE_BASE_RELOCATION>()
+				}
+				else {
+					next_offset
+				};
+
+				let ty = (word >> 12) as u8;
+				if ty != IMAGE_REL_BASED_ABSOLUTE {
+					let rva = image.VirtualAddress + (word & 0x0fff) as Rva;
+					return Some(rva);
+				}
+			}
+		}
+		None
+	}
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		// Rough upper bound, ignoring base relocation blocks and padding
+		let upper_bound = self.iter.as_slice().len() / 2;
+		(0, Some(upper_bound))
+	}
+	// Should implement `try_fold` instead but it uses unstable features.
+	fn fold<B, F>(self, init: B, mut f: F) -> B
+		where F: FnMut(B, Self::Item) -> B,
+	{
+		let mut accum = init;
+		// The outer loop iterates over base relocation blocks
+		let mut bytes = self.iter.as_slice();
+		let mut offset = self.offset;
+		while bytes.len() != 0 {
+			// Safety checked by new
+			unsafe {
+				// The inner loop iterates over the relocation words
+				let image = &*(bytes.as_ptr() as *const IMAGE_BASE_RELOCATION);
+				while offset < image.SizeOfBlock as usize {
+					let word = *(bytes.as_ptr().offset(offset as isize) as *const u16);
+					// Filter out padding relocations
+					let ty = (word >> 12) as u8;
+					if ty != IMAGE_REL_BASED_ABSOLUTE {
+						let rva = image.VirtualAddress + (word & 0x0fff) as Rva;
+						accum = f(accum, rva);
+					}
+					offset += 2;
+				}
+				// Advance to the next base relocation block and reset the offset to the first word
+				bytes = bytes.get_unchecked(image.SizeOfBlock as usize..);
+				offset = mem::size_of::<IMAGE_BASE_RELOCATION>();
+			}
+		}
+		accum
+	}
+}
+impl<'a> iter::FusedIterator for Iter<'a> {}
+
+//----------------------------------------------------------------
+
+/// Iterator over the base relocation blocks.
 #[derive(Clone)]
-pub struct Iter<'a, P> {
+pub struct IterBlocks<'a, P> {
 	pe: P,
 	iter: slice::Iter<'a, u8>,
 }
-impl<'a, P: Pe<'a> + Copy> Iterator for Iter<'a, P> {
+impl<'a, P: Pe<'a> + Copy> Iterator for IterBlocks<'a, P> {
 	type Item = Block<'a, P>;
 	fn next(&mut self) -> Option<Block<'a, P>> {
 		if self.iter.len() != 0 {
-			// This is safe as it should have been checked in `new`.
+			// Safety checked by new
 			unsafe {
 				let slice = self.iter.as_slice();
 				let image = &*(slice.as_ptr() as *const IMAGE_BASE_RELOCATION);
@@ -119,6 +205,7 @@ impl<'a, P: Pe<'a> + Copy> Block<'a, P> {
 	}
 	/// Gets the types and offsets.
 	pub fn words(&self) -> &'a [u16] {
+		// Safety checked by new
 		unsafe {
 			let p = (self.image as *const IMAGE_BASE_RELOCATION).offset(1) as *const u16;
 			let len = (self.image.SizeOfBlock as usize - mem::size_of::<IMAGE_BASE_RELOCATION>()) / 2;
@@ -131,18 +218,8 @@ impl<'a, P: Pe<'a> + Copy> Block<'a, P> {
 		self.image.VirtualAddress + offset
 	}
 	/// Gets the type of a typeoffset.
-	pub fn type_of(&self, &word: &u16) -> u8 {
-		((word >> 12) & 0xFF) as u8
-	}
-}
-impl<'a, P: Pe<'a> + Copy> IntoIterator for Block<'a, P> {
-	type Item = Rva;
-	type IntoIter = BlockIter<'a>;
-	fn into_iter(self) -> BlockIter<'a> {
-		BlockIter {
-			rva: self.image.VirtualAddress,
-			iter: self.words().iter(),
-		}
+	pub fn type_of(&self, word: &u16) -> u8 {
+		(word >> 12) as u8
 	}
 }
 impl<'a, P: Pe<'a> + Copy> fmt::Debug for Block<'a, P> {
@@ -150,28 +227,5 @@ impl<'a, P: Pe<'a> + Copy> fmt::Debug for Block<'a, P> {
 		f.debug_struct("Block")
 			.field("words.len", &self.words().len())
 			.finish()
-	}
-}
-
-
-//----------------------------------------------------------------
-
-pub struct BlockIter<'a> {
-	rva: Rva,
-	iter: slice::Iter<'a, u16>,
-}
-impl<'a> Iterator for BlockIter<'a> {
-	type Item = Rva;
-	fn next(&mut self) -> Option<Rva> {
-		self.iter.next().and_then(|&word| {
-			let ty = ((word >> 12) & 0xFF) as u8;
-			if ty != IMAGE_REL_BASED_ABSOLUTE {
-				let offset = (word & 0x0FFF) as Rva;
-				Some(self.rva + offset)
-			}
-			else {
-				None
-			}
-		})
 	}
 }


### PR DESCRIPTION
I was very unhappy with the API, the only way to get something done required knowing the internal details of the base relocations.

So here's the new API:

`BaseRelocs::into_iter` gets you an iterator returning all the `Rva`s of relocations, skipping absolute relocs without giving relocation type information. Super simple and works as expected.

`BaseRelocs::iter_blocks` gets you an iterator over the relocation blocks. Advanced.

That seems nice.