### PR TITLE
Exports query non sorted name table

### DIFF
--- a/src/util/c_str.rs
+++ b/src/util/c_str.rs
@@ -15,6 +15,10 @@ pub struct CStr {
 }
 
 impl CStr {
+	/// Returns the empty nul-terminated C string.
+	pub fn empty() -> &'static CStr {
+		unsafe { CStr::from_bytes_unchecked(&[0]) }
+	}
 	/// Scans the byte slice for a nul-terminated C string.
 	///
 	/// Returns `None` if no nul byte was found.


### PR DESCRIPTION
This came up when writing tests, this API allows to check if the name table is valid and provides a linear scan lookup by name which doesn't fail on corrupted name table entries.