### PR TITLE
Encode resources with data-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ opt-level = 2
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
+data-encoding = { version = "2.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ Due to small but incompatible differences the two formats are not unified.
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "data-encoding")]
+extern crate data_encoding;
+
 #[macro_use]
 pub mod util;
 


### PR DESCRIPTION
Optional dependency on data-encoding, encodes resources data bytes as base64 strings if the feature is enabled and the serializer is human readable.