### PR TITLE
Support YARA hex strings Part2

### DIFF
--- a/src/pe64/scanner.rs
+++ b/src/pe64/scanner.rs
@@ -146,10 +146,12 @@ impl<'a, 'u, P: Pe<'a> + Copy> Exec<'u, P> {
 				pat::Atom::Push(skip) => {
 					let skip = calc_skip(skip, skip_ext);
 					let cursor = self.cursor.wrapping_add(skip as u32);
-					skip_ext = 0;
 					if !self.exec(save) {
 						return false;
 					}
+					mask = 0xff;
+					skip_ext = 0;
+					many_ext = 0;
 					self.cursor = cursor;
 				},
 				pat::Atom::Pop => {


### PR DESCRIPTION
Improve parser feedback, now has nicer error message and shows the position in the pattern where the syntax is faulty.

Add tests for the skip many feature, improve documentation of the skip many feature and trim what the parser accepts as valid, this is open for extension as needed.

Some refactoring of the parser code, it's still ugly however...
