### PR TITLE
Align wrapper utils

### DIFF
--- a/src/util/align.rs
+++ b/src/util/align.rs
@@ -1,0 +1,12 @@
+
+/// Ensures alignment of at least 16 bytes.
+#[repr(align(16))]
+pub struct Align16<T>(pub T);
+
+/// Ensures alignment of at least 512 bytes.
+#[repr(align(512))]
+pub struct Align512<T>(pub T);
+
+/// Ensures alignment of at least 4K bytes.
+#[repr(align(4096))]
+pub struct Align4K<T>(pub T);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -25,12 +25,14 @@ macro_rules! offset_of {
 mod c_str;
 mod wide_str;
 mod guid;
+mod align;
 
 #[cfg(feature = "serde")]
 pub(crate) mod serde_helper;
 
 pub use self::c_str::CStr;
 pub use self::wide_str::WideStr;
+pub use self::align::*;
 
 /// Converts from a byte slice to a string.
 pub trait FromBytes {


### PR DESCRIPTION
Useful for embedding binary files in the executable image with specific alignment, otherwise `include_bytes!` only has alignment of 1.