### PR TITLE
Refactor Resource Naming

### DIFF
--- a/examples/extract-icons.rs
+++ b/examples/extract-icons.rs
@@ -1,8 +1,7 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::{PathBuf};
 
 use pelite::{FileMap, PeFile};
-use pelite::resources::*;
 
 const HELP_TEXT: &str = "\
 EXTRACT-ICONS <BINARY> <DEST>

--- a/src/resources/art.rs
+++ b/src/resources/art.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use super::{Resources, Directory, Entry, Name};
+use super::{Resources, Directory, Entry};
 use crate::stringify::RSRC_TYPES;
 
 /// Art used to format a directory tree.
@@ -87,20 +87,7 @@ impl<'a, 'd> TreeFmt<'a, 'd> {
 			f.write_str(prefix)?;
 			// Print the file_name
 			match e.name() {
-				Ok(Name::Id(id)) => {
-					// At root level some resource ids have special names
-					let get_rsrc_name = || {
-						if root { RSRC_TYPES.get(id as usize).and_then(|&a| a) }
-						else { None }
-					};
-					if let Some(name) = get_rsrc_name() {
-						write!(f, "{}", name)
-					}
-					else {
-						write!(f, "{}", id)
-					}
-				},
-				Ok(Name::Str(s)) => write!(f, "{}", s),
+				Ok(name) => name.display(f, if root { &RSRC_TYPES } else { &[] }),
 				Err(err) => write!(f, "{}", err),
 			}.and_then(|_| {
 				f.write_str(if e.is_dir() { "/\n" } else { "\n" })

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -23,6 +23,7 @@ macro_rules! offset_of {
 }
 
 mod c_str;
+#[allow(dead_code)]
 mod wide_str;
 mod guid;
 mod align;
@@ -32,7 +33,7 @@ mod string_n;
 pub(crate) mod serde_helper;
 
 pub use self::c_str::CStr;
-pub use self::wide_str::WideStr;
+// pub use self::wide_str::WideStr;
 pub use self::align::*;
 pub use self::string_n::StringN;
 

--- a/tests/demo64.rs
+++ b/tests/demo64.rs
@@ -175,10 +175,13 @@ fn find_data() {
 	let file_map = FileMap::open(FILE_NAME).unwrap();
 	let file = PeFile::from_bytes(&file_map).unwrap();
 	let resources = file.resources().unwrap();
-	let data = resources.find_data("/Manifest/2/1033").unwrap();
+	let data = resources.find_data("/Manifest/#2/#1033").unwrap();
 	let bytes = data.bytes().unwrap();
 	let manifest = std::str::from_utf8(bytes).unwrap();
 	println!("\n{}", manifest);
+
+	let data2 = resources.find_dir("/Manifest").unwrap().get_dir("#2".into()).unwrap().get_data("#1033".into()).unwrap();
+	assert!(std::ptr::eq(data.image(), data2.image()));
 }
 
 //----------------------------------------------------------------


### PR DESCRIPTION
This PR is fairly heavy on breaking changes...

* Name now has an extra entry for Rust strings.
* When referring to resource names with Rust strings now expecting `#` prefix to match resource ids.
* Now consistently prints `#` prefix for resource ids.
* 'Deprecating' `WideStr` by straight up removing it.

Closes #191