### PR TITLE
Small update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,15 @@ name = "pelite"
 version = "0.8.0"
 authors = ["Casper <CasualX@users.noreply.github.com>"]
 edition = "2018"
+license = "MIT"
 
 description = "Lightweight, memory-safe, zero-allocation library for reading and navigating PE binaries."
-
 documentation = "https://docs.rs/pelite/"
 repository = "https://github.com/CasualX/pelite"
-
 readme = "readme.md"
-
 keywords = ["exe", "dll", "mui", "bin", "pe"]
 categories = ["parser-implementations", "command-line-utilities"]
-
-license = "MIT"
+exclude = ["tests/pocs/blob"]
 
 [workspace]
 members = [".", "./src/proc-macros", "./wasm"]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] 2020-04-15
+
+Small patch to remove the `pocs/blob` file from the published crate.
+This avoids issues with antivirus false-positive detecting this file as malicious.
+
 ## [0.8.0] 2019-09-12
 
 Pelite is now developed in Rust Edition 2018!
@@ -134,6 +139,11 @@ Support more general purpose analysis features for discovery rather than automat
 - Changed Ptr's methods where const fn has been stablized.
 - Fixed Ptr's type parameter variance.
 - Removed WideStr from utils, it didn't do what you thought it did.
+
+## [0.7.2] 2020-04-15
+
+Small patch to remove the `pocs/blob` file from the published crate.
+This avoids issues with antivirus false-positive detecting this file as malicious.
 
 ## [0.7.1] 2018-09-20
 

--- a/examples/apisetschema/win10.rs
+++ b/examples/apisetschema/win10.rs
@@ -1,5 +1,4 @@
 use std::{fmt, mem, slice};
-use std::error::Error as _;
 use pelite::{Result, Error, Pod};
 use pelite::util::AlignTo;
 use super::image::*;
@@ -108,7 +107,7 @@ impl<'a> fmt::Debug for Entry<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("Entry")
 			.field("is_sealed", &self.is_sealed())
-			.field("name", &self.name().map(String::from_utf16_lossy).unwrap_or_else(|err| err.description().into()))
+			.field("name", &self.name().map(String::from_utf16_lossy).unwrap_or_else(|err| err.to_string()))
 			.field("values", &self.values())
 			.finish()
 	}
@@ -165,8 +164,8 @@ impl<'a> fmt::Debug for Value<'a> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("Value")
 			.field("is_sealed", &self.is_sealed())
-			.field("api_set_name", &self.api_set_name().map(String::from_utf16_lossy).unwrap_or_else(|err| err.description().into()))
-			.field("host_name", &self.host_name().map(String::from_utf16_lossy).unwrap_or_else(|err| err.description().into()))
+			.field("api_set_name", &self.api_set_name().map(String::from_utf16_lossy).unwrap_or_else(|err| err.to_string()))
+			.field("host_name", &self.host_name().map(String::from_utf16_lossy).unwrap_or_else(|err| err.to_string()))
 			.finish()
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,43 +87,35 @@ impl Error {
 	pub fn is_null(self) -> bool {
 		self == Error::Null
 	}
-}
 
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	/// Returns a simple string representation of the error.
+	pub fn to_str(self) -> &'static str {
 		match self {
-			Error::Null => f.write_str("Null address reference"),
-			Error::Bounds => f.write_str("Bounds check failed"),
-			Error::ZeroFill => f.write_str("Zero filled data reference"),
-			Error::Unmapped => f.write_str("Overlay data reference"),
-			Error::Misaligned => f.write_str("Address misaligned"),
-			Error::BadMagic => f.write_str("Unknown magic number"),
-			Error::PeMagic => f.write_str("Retry with the correct parser"),
-			Error::Insanity => f.write_str("Data insanity"),
-			Error::Invalid => f.write_str("Invalid data"),
-			Error::Overflow => f.write_str("Overflow error"),
-			Error::Encoding => f.write_str("Encoding error"),
-			Error::Aliasing => f.write_str("Aliasing error"),
-		}
-	}
-}
-
-impl error::Error for Error {
-	fn description(&self) -> &str {
-		match self {
-			Error::Null => "null address",
-			Error::Bounds => "out of bounds",
-			Error::ZeroFill => "zero fill",
-			Error::Unmapped => "unmapped",
-			Error::Misaligned => "misaligned",
-			Error::BadMagic => "bad magic",
-			Error::PeMagic => "incorrect bitness",
-			Error::Insanity => "insanity",
+			Error::Null => "null address reference",
+			Error::Bounds => "bounds check failed",
+			Error::ZeroFill => "zero filled data reference",
+			Error::Unmapped => "overlay data reference",
+			Error::Misaligned => "address misaligned",
+			Error::BadMagic => "unknown magic number",
+			Error::PeMagic => "try again with correct parser",
+			Error::Insanity => "data insanity",
 			Error::Invalid => "invalid data",
 			Error::Overflow => "overflow error",
 			Error::Encoding => "encoding error",
 			Error::Aliasing => "aliasing error",
 		}
+	}
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.write_str(self.to_str())
+	}
+}
+
+impl error::Error for Error {
+	fn description(&self) -> &str {
+		self.to_str()
 	}
 }
 

--- a/src/mmap/windows.rs
+++ b/src/mmap/windows.rs
@@ -1,5 +1,5 @@
 
-use std::{io, mem, ptr, slice};
+use std::{io, mem, ptr};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::os::windows::ffi::OsStrExt;
@@ -48,7 +48,7 @@ impl ImageMap {
 					let dos_header = view as *const IMAGE_DOS_HEADER;
 					let nt_header = (view as usize + (*dos_header).e_lfanew as usize) as *const IMAGE_NT_HEADERS64;
 					let size_of = (*nt_header).OptionalHeader.SizeOfImage;
-					let bytes = slice::from_raw_parts_mut(view as *mut u8, size_of as usize);
+					let bytes = ptr::slice_from_raw_parts_mut(view as *mut u8, size_of as usize);
 					return Ok(ImageMap { handle: map, bytes });
 				}
 				let err = io::Error::last_os_error();
@@ -120,7 +120,7 @@ impl FileMap {
 		let vq_result = VirtualQuery(view, &mut mem_basic_info, mem::size_of_val(&mem_basic_info));
 		debug_assert_eq!(vq_result, mem::size_of_val(&mem_basic_info));
 		// Now have enough information to construct the FileMap
-		let bytes = slice::from_raw_parts_mut(view as *mut u8, mem_basic_info.RegionSize as usize);
+		let bytes = ptr::slice_from_raw_parts_mut(view as *mut u8, mem_basic_info.RegionSize as usize);
 		Ok(FileMap { handle: map, bytes })
 	}
 }

--- a/src/proc-macros/lib.rs
+++ b/src/proc-macros/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::*;
 
 /// Compile time pattern parser.

--- a/src/proc-macros/pattern.rs
+++ b/src/proc-macros/pattern.rs
@@ -55,26 +55,12 @@ pub struct ParsePatError {
 }
 impl fmt::Display for ParsePatError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "Syntax Error @{}: {}.", self.position, error::Error::description(self))
+		write!(f, "Syntax Error @{}: {}.", self.position, self.kind.to_str())
 	}
 }
 impl error::Error for ParsePatError {
 	fn description(&self) -> &str {
-		match self.kind {
-			PatError::UnpairedHexDigit => "Unpaired hex digit",
-			PatError::UnknownChar => "Unknown character",
-			PatError::ManyOverflow => "Many range exceeded",
-			PatError::ManyRange => "Many bounds nonsensical",
-			PatError::ManyInvalid => "Many invalid syntax",
-			PatError::SaveOverflow => "Save store overflow",
-			PatError::StackError => "Stack unbalanced",
-			PatError::StackInvalid => "Stack must follow jump",
-			PatError::UnclosedQuote => "String missing end quote",
-			PatError::AlignedOperand => "Aligned operand error",
-			PatError::ReadOperand => "Read operand error",
-			PatError::SubPattern => "Sub pattern error",
-			PatError::SubOverflow => "Sub pattern too large",
-		}
+		self.kind.to_str()
 	}
 }
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -92,6 +78,25 @@ enum PatError {
 	ReadOperand,
 	SubPattern,
 	SubOverflow,
+}
+impl PatError {
+	fn to_str(self) -> &'static str {
+		match self {
+			PatError::UnpairedHexDigit => "unpaired hex digit",
+			PatError::UnknownChar => "unknown character",
+			PatError::ManyOverflow => "many range exceeded",
+			PatError::ManyRange => "many bounds nonsensical",
+			PatError::ManyInvalid => "many invalid syntax",
+			PatError::SaveOverflow => "save store overflow",
+			PatError::StackError => "stack unbalanced",
+			PatError::StackInvalid => "stack must follow jump",
+			PatError::UnclosedQuote => "string missing end quote",
+			PatError::AlignedOperand => "aligned operand error",
+			PatError::ReadOperand => "read operand error",
+			PatError::SubPattern => "sub pattern error",
+			PatError::SubOverflow => "sub pattern too large",
+		}
+	}
 }
 
 //----------------------------------------------------------------
@@ -545,7 +550,7 @@ fn parse_helper(pat: &mut &str, result: &mut Vec<Atom>) -> Result<(), PatError> 
 				save += 1;
 			},
 			// Allow spaces as padding
-			b' ' => {},
+			b' ' | b'\n' | b'\r' | b'\t' => {},
 			// Everything else is illegal
 			_ => {
 				return Err(PatError::UnknownChar);

--- a/src/resources/find.rs
+++ b/src/resources/find.rs
@@ -33,6 +33,19 @@ pub enum FindError {
 	/// Encountered a directory when expecting a data entry.
 	UnDirectory,
 }
+impl FindError {
+	/// Returns a simple string representation of the error.
+	pub fn to_str(self) -> &'static str {
+		match self {
+			FindError::Pe(err) => err.to_str(),
+			FindError::Bad8Path => "invalid utf8 path",
+			FindError::NotFound => "entry not found",
+			FindError::NoRootPath => "missing '/' root",
+			FindError::UnDataEntry => "unexpected data entry",
+			FindError::UnDirectory => "unexpected directory",
+		}
+	}
+}
 impl From<crate::Error> for FindError {
 	fn from(err: crate::Error) -> FindError {
 		FindError::Pe(err)
@@ -45,19 +58,12 @@ impl From<str::Utf8Error> for FindError {
 }
 impl fmt::Display for FindError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		error::Error::description(self).fmt(f)
+		self.to_str().fmt(f)
 	}
 }
 impl error::Error for FindError {
 	fn description(&self) -> &str {
-		match self {
-			FindError::Pe(err) => err.description(),
-			FindError::Bad8Path => "Invalid utf8 path",
-			FindError::NotFound => "Entry not found",
-			FindError::NoRootPath => "Missing '/' root",
-			FindError::UnDataEntry => "Unexpected data entry",
-			FindError::UnDirectory => "Unexpected directory",
-		}
+		self.to_str()
 	}
 	fn cause(&self) -> Option<&dyn error::Error> {
 		self.source()


### PR DESCRIPTION
* Stop using deprecated `Error::description`
* Exclude tests/pocs/blob due to antivirus false positive
* Patterns accept newlines and tabs as whitespace