### PR TITLE
Fix case of incorrect parsing of square brackets

### DIFF
--- a/src/proc-macros/pattern.rs
+++ b/src/proc-macros/pattern.rs
@@ -410,10 +410,12 @@ fn parse_helper(pat: &mut &str, result: &mut Vec<Atom>) -> Result<(), PatError> 
 					return Err(PatError::ManyInvalid);
 				}
 				// Turn the lower bound into skip ops
-				if lower_bound >= 256 {
-					result.push(Atom::Rangext((lower_bound >> 8) as u8));
+				if lower_bound > 0 {
+					if lower_bound >= 256 {
+						result.push(Atom::Rangext((lower_bound >> 8) as u8));
+					}
+					result.push(Atom::Skip((lower_bound & 0xff) as u8));
 				}
-				result.push(Atom::Skip((lower_bound & 0xff) as u8));
 				// Second many part is optional
 				if chr == b']' {
 					continue;


### PR DESCRIPTION
The Skip atom with an argument of zero means to skip a number of bytes equal to the width of a pointer on the target platform.
The parser for the square brackets incorrectly generated a Skip atom with argument zero if the lower bound was zero.