### PR TITLE
Enabling the ability to implement a lazily evaluated PeView 

### DIFF
--- a/src/pe64/debug.rs
+++ b/src/pe64/debug.rs
@@ -143,13 +143,12 @@ impl<'a, P: Pe<'a>> Dir<'a, P> {
 	}
 	/// Gets the raw data of this debug directory entry.
 	pub fn data(&self) -> Option<&'a [u8]> {
-		let image = self.pe.image();
 		let size = self.image.SizeOfData as usize;
 		let offset = match self.pe.align() {
 			Align::File => self.image.PointerToRawData,
 			Align::Section => self.image.AddressOfRawData,
 		} as usize;
-		image.get(offset..offset.wrapping_add(size))
+		self.pe.image_slice(offset, size)
 	}
 	/// Interprets the directory entry.
 	pub fn entry(&self) -> Result<Entry<'a>> {

--- a/src/pe64/pe.rs
+++ b/src/pe64/pe.rs
@@ -212,6 +212,11 @@ pub unsafe trait Pe<'a>: PeObject<'a> + Copy {
 
 	//----------------------------------------------------------------
 
+	/// Slices the raw image buffer at the specified offset
+	fn image_slice(&self, offset: usize, size: usize) -> Option<&'a [u8]> {
+		self.image().get(offset..offset.wrapping_add(size))
+	}
+
 	/// Slices the image at the specified rva.
 	///
 	/// If successful the returned slice's length will be at least the given size but often be quite larger.

--- a/src/pe64/scanner.rs
+++ b/src/pe64/scanner.rs
@@ -554,7 +554,7 @@ impl<'a, 'pat, P: Pe<'a>> Matches<'pat, P> {
 					// If section overlaps with the scanning range
 					if section.VirtualAddress < self.range.end && u32::wrapping_add(section.VirtualAddress, section.VirtualSize) > self.range.start {
 						// Get the image slice for this section for further processing, skipping corrupt section headers
-						if let Some(slice) = image.get(section.PointerToRawData as usize..u32::wrapping_add(section.PointerToRawData, section.SizeOfRawData) as usize) {
+						if let Some(slice) = self.scanner.pe.image_slice(section.PointerToRawData as usize, section.SizeOfRawData as usize) {
 							if self.next_section(qsbuf, section.VirtualAddress, slice, save) {
 								return true;
 							}

--- a/src/pe64/scanner.rs
+++ b/src/pe64/scanner.rs
@@ -547,7 +547,6 @@ impl<'a, 'pat, P: Pe<'a>> Matches<'pat, P> {
 		let mut qsbuf = [0u8; QS_BUF_LEN];
 		let qsbuf = self.setup(&mut qsbuf);
 
-		let image = self.scanner.pe.image();
 		match self.scanner.pe.align() {
 			Align::File => {
 				for section in self.scanner.pe.section_headers() {
@@ -564,7 +563,11 @@ impl<'a, 'pat, P: Pe<'a>> Matches<'pat, P> {
 				false
 			},
 			Align::Section => {
-				self.next_section(qsbuf, 0, image, save)
+				if let Some(slice) = self.scanner.pe.image_slice(self.range.start as usize, (self.range.end - self.range.start) as usize) {
+					self.next_section(qsbuf, self.range.start, slice, save)
+				} else {
+					false
+				}
 			},
 		}
 	}


### PR DESCRIPTION
Instead of calling the get() function on the image slice directly this commit adds a small convenience function which will just get a slice of the underlying image buffer at a specific offset. This will enable users to build their own lazy version of a PeView by intercepting all the calls to the Pe trait.