### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dataview = { version = "0.1", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 data-encoding = { version = "2.1", optional = true }
 no-std-compat = { version = "0.4.0", features = ["alloc"] }
-hashbrown = "0.8.0"
+hashbrown = { version = "0.8.0", features = ["serde"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ members = [".", "./src/proc-macros", "./wasm"]
 [features]
 default = ["mmap", "derive_pod"]
 unsafe_alignment = []
-mmap = ["libc", "winapi"]
+mmap = ["std", "libc", "winapi"]
 unstable = []
 derive_pod = ["dataview/derive_pod"]
+std = ["no-std-compat/std"]
 
 [badges]
 appveyor = { repository = "CasualX/pelite", branch = "master", service = "github" }
@@ -41,6 +42,8 @@ pelite-macros = { path = "src/proc-macros", version = "0.1.0" }
 dataview = { version = "0.1", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 data-encoding = { version = "2.1", optional = true }
+no-std-compat = { version = "0.4.0", features = ["alloc"] }
+hashbrown = "0.8.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ mmap = ["std", "libc", "winapi"]
 unstable = []
 derive_pod = ["dataview/derive_pod"]
 std = ["no-std-compat/std"]
+resources_nostd = ["hashbrown"]
 
 [badges]
 appveyor = { repository = "CasualX/pelite", branch = "master", service = "github" }
@@ -43,7 +44,7 @@ dataview = { version = "0.1", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 data-encoding = { version = "2.1", optional = true }
 no-std-compat = { version = "0.4.0", features = ["alloc"] }
-hashbrown = { version = "0.8.0", features = ["serde"] }
+hashbrown = { version = "0.8.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/src/base_relocs.rs
+++ b/src/base_relocs.rs
@@ -29,11 +29,13 @@ fn example(file: PeFile<'_>) -> pelite::Result<()> {
 ```
  */
 
+use std::prelude::v1::*;
+
 use std::{cmp, fmt, iter, mem, slice};
 
 use crate::image::{IMAGE_BASE_RELOCATION, IMAGE_REL_BASED_ABSOLUTE};
-use crate::util::{AlignTo, extend_in_place};
-use crate::{Result, Error};
+use crate::util::{extend_in_place, AlignTo};
+use crate::{Error, Result};
 
 /// Base Relocations Directory.
 ///
@@ -44,7 +46,7 @@ pub struct BaseRelocs<'a> {
 }
 impl<'a> BaseRelocs<'a> {
 	pub(crate) unsafe fn new(relocs: &'a [u8]) -> BaseRelocs<'a> {
-		debug_assert!(relocs.as_ptr().aligned_to(4), 0); // $1
+		debug_assert!(relocs.as_ptr().aligned_to(4)); // $1
 		BaseRelocs { relocs }
 	}
 	/// Parse a base relocations directory.

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,10 @@
 Errors and Results.
 */
 
-use std::{error, fmt, result, str};
+use std::{fmt, result, str};
+
+#[cfg(feature = "std")]
+use std::error;
 
 /// Errors while parsing the PE binary.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -113,6 +116,7 @@ impl fmt::Display for Error {
 	}
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {
 	fn description(&self) -> &str {
 		self.to_str()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ Due to small but incompatible differences the two formats are not unified.
 
 #![recursion_limit = "128"]
 #![allow(ellipsis_inclusive_range_patterns)]
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate no_std_compat as std;
 
 #[macro_use]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub use self::pe32 as pe;
 pub use self::pe64 as pe;
 
 pub mod base_relocs;
+
+#[cfg(any(feature = "std", feature = "resources_nostd"))]
 pub mod resources;
 pub mod rich_structure;
 pub mod security;

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -2,7 +2,9 @@
 PE file.
 */
 
-use crate::{Result};
+use std::prelude::v1::*;
+
+use crate::Result;
 
 use super::pe::validate_headers;
 use super::{Align, Pe, PeObject};

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -2,6 +2,8 @@
 PE view.
 */
 
+use std::prelude::v1::*;
+
 use std::{cmp, slice};
 
 use crate::{Error, Result};

--- a/src/proc-macros/pattern.rs
+++ b/src/proc-macros/pattern.rs
@@ -38,7 +38,12 @@ Here's a resource to learn more about signature scanning: [wiki.alliedmods.net](
 
 #![allow(ellipsis_inclusive_range_patterns)]
 
-use std::{cmp, error, fmt, mem, str};
+use std::prelude::v1::*;
+
+use std::{cmp, fmt, mem, str};
+
+#[cfg(feature = "std")]
+use std::error;
 
 /// Max recursion depth.
 pub const STACK_SIZE: usize = 4;
@@ -58,6 +63,7 @@ impl fmt::Display for ParsePatError {
 		write!(f, "Syntax Error @{}: {}.", self.position, self.kind.to_str())
 	}
 }
+#[cfg(feature = "std")]
 impl error::Error for ParsePatError {
 	fn description(&self) -> &str {
 		self.kind.to_str()

--- a/src/resources/find.rs
+++ b/src/resources/find.rs
@@ -2,8 +2,10 @@
 Resources Find API.
 */
 
-use std::{error, fmt, str};
-use std::path::Path;
+use std::{fmt, str};
+
+#[cfg(feature = "std")]
+use std::{error, path::Path};
 
 use super::{Resources, Directory, Entry, Name, DataEntry};
 
@@ -61,6 +63,7 @@ impl fmt::Display for FindError {
 		self.to_str().fmt(f)
 	}
 }
+#[cfg(feature = "std")]
 impl error::Error for FindError {
 	fn description(&self) -> &str {
 		self.to_str()
@@ -162,6 +165,7 @@ impl<'a> Directory<'a> {
 
 //------------------------------------------------
 
+#[cfg(feature = "std")]
 impl<'a> Resources<'a> {
 	/// Finds a file or directory by its path.
 	pub fn find<P: AsRef<Path> + ?Sized>(&self, path: &P) -> Result<Entry<'a>, FindError> {
@@ -193,6 +197,7 @@ impl<'a> Resources<'a> {
 		}
 	}
 }
+#[cfg(feature = "std")]
 impl<'a> Directory<'a> {
 	/// Finds a file or directory by its path.
 	pub fn find<P: AsRef<Path> + ?Sized>(&self, path: &P) -> Result<Entry<'a>, FindError> {

--- a/src/resources/group.rs
+++ b/src/resources/group.rs
@@ -40,12 +40,17 @@ for (name, group) in resources.icons().filter_map(Result::ok) {
 
  */
 
-use std::{fmt, io, mem, slice};
-use crate::{Error};
-use crate::util::{AlignTo};
-use crate::Pod;
+use std::prelude::v1::*;
 
-use super::{Resources, FindError};
+#[cfg(feature = "std")]
+use std::io;
+
+use crate::util::AlignTo;
+use crate::Error;
+use crate::Pod;
+use std::{fmt, mem, slice};
+
+use super::{FindError, Resources};
 
 use self::image::*;
 
@@ -129,6 +134,7 @@ impl<'a> GroupResource<'a> {
 			.bytes().map_err(FindError::Pe)
 	}
 	/// Reassemble the file.
+	#[cfg(feature = "std")]
 	pub fn write(&self, dest: &mut dyn io::Write) -> io::Result<()> {
 		// Start by appending the header
 		dest.write(self.image.as_bytes())?;

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -2,6 +2,8 @@
 Resources.
 */
 
+use std::prelude::v1::*;
+
 use std::{char, fmt, iter, mem, slice};
 
 use crate::{Pod, Error, Result};

--- a/src/resources/version_info.rs
+++ b/src/resources/version_info.rs
@@ -40,7 +40,11 @@ fn example(bin: PeFile<'_>) -> Result<(), pelite::resources::FindError> {
 
  */
 
+#[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+
 use std::prelude::v1::*;
 use std::{char, cmp, fmt, mem, slice};
 
@@ -364,7 +368,7 @@ FILESUBTYPE {}",
 
 /// VersionInfo parsed into HashMaps.
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize))]
+#[cfg_attr(all(feature = "std", feature = "serde"), derive(::serde::Serialize))]
 pub struct FileInfo<'a> {
 	pub fixed: Option<&'a VS_FIXEDFILEINFO>,
 	pub strings: HashMap<Language, HashMap<String, String>>,
@@ -411,7 +415,7 @@ impl<'a> Visit<'a> for FileInfo<'a> {
 	},
 */
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "std", feature = "serde"))]
 mod serde {
 	use crate::util::serde_helper::*;
 	use super::{Language, VersionInfo};

--- a/src/resources/version_info.rs
+++ b/src/resources/version_info.rs
@@ -326,7 +326,7 @@ FILETYPE {}
 FILESUBTYPE {}",
 				fixed.dwFileVersion.Major, fixed.dwFileVersion.Minor, fixed.dwFileVersion.Patch, fixed.dwFileVersion.Build,
 				fixed.dwProductVersion.Major, fixed.dwProductVersion.Minor, fixed.dwProductVersion.Patch, fixed.dwProductVersion.Build,
-				fixed.dwFileFlagsMask, fixed.dwFileFlags, fixed.dwFileOS >> 16,	fixed.dwFileOS & 0xffff, fixed.dwFileType, fixed.dwFileSubtype);
+				fixed.dwFileFlagsMask, fixed.dwFileFlags, fixed.dwFileOS >> 16, fixed.dwFileOS & 0xffff, fixed.dwFileType, fixed.dwFileSubtype);
 		}
 		true
 	}

--- a/src/resources/version_info.rs
+++ b/src/resources/version_info.rs
@@ -40,13 +40,15 @@ fn example(bin: PeFile<'_>) -> Result<(), pelite::resources::FindError> {
 
  */
 
+use hashbrown::HashMap;
+use std::prelude::v1::*;
 use std::{char, cmp, fmt, mem, slice};
-use std::collections::HashMap;
+
 use std::fmt::Write;
 
 use crate::image::VS_FIXEDFILEINFO;
-use crate::{Error, Result, Pod};
-use crate::util::{AlignTo, FmtUtf16, wstrn};
+use crate::util::{wstrn, AlignTo, FmtUtf16};
+use crate::{Error, Pod, Result};
 
 //----------------------------------------------------------------
 
@@ -320,7 +322,7 @@ FILETYPE {}
 FILESUBTYPE {}",
 				fixed.dwFileVersion.Major, fixed.dwFileVersion.Minor, fixed.dwFileVersion.Patch, fixed.dwFileVersion.Build,
 				fixed.dwProductVersion.Major, fixed.dwProductVersion.Minor, fixed.dwProductVersion.Patch, fixed.dwProductVersion.Build,
-				fixed.dwFileFlagsMask, fixed.dwFileFlags, fixed.dwFileOS >> 16, fixed.dwFileOS & 0xffff, fixed.dwFileType, fixed.dwFileSubtype);
+				fixed.dwFileFlagsMask, fixed.dwFileFlags, fixed.dwFileOS >> 16,	fixed.dwFileOS & 0xffff, fixed.dwFileType, fixed.dwFileSubtype);
 		}
 		true
 	}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,6 +2,8 @@
 Utilities and other tidbits.
 */
 
+use std::prelude::v1::*;
+
 // For testing, assert that structs have specified ABI size
 #[cfg(test)]
 macro_rules! assert_size_of {
@@ -104,6 +106,7 @@ pub fn wstrn(buf: &[u16]) -> &[u16] {
 }
 
 /// Bits of entropy represented in a given byte slice.
+#[cfg(feature = "std")]
 pub fn shannon_entropy(data: &[u8]) -> f64 {
 	let mut map = [0usize; 256];
 

--- a/src/util/wide_str.rs
+++ b/src/util/wide_str.rs
@@ -2,6 +2,7 @@
 Length word prefixed wide string.
 */
 
+use std::prelude::v1::*;
 use std::{char, fmt, mem, slice, ops};
 
 use crate::util::FromBytes;


### PR DESCRIPTION
Limit file operations and `mmap` feature to environments with standard library. Otherwise, do not depend on it. This also requires limiting `std::error::Error` implementation in error types only in std environments. Other than that, we are pulling Google's hashbrown, since `alloc::collections` does not include HashMap.