### PR TITLE
Implement simple source

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -118,9 +118,9 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl error::Error for Error {
-	fn description(&self) -> &str {
-		self.to_str()
-	}
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
+    }
 }
 
 /// Specialized `Result` type for PE errors.


### PR DESCRIPTION
Hello,

The PR 
 - removes `description` from `Error` since the method is deprecated now,
 - adds a trivial ``source`