### PR TITLE
Use correct base address for 32-bit ASLR images

### DIFF
--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -84,7 +84,7 @@ unsafe impl<'a> PeObject<'a> for PeFile<'a> {
 		Align::File
 	}
 
-	fn base_addr(&self) -> super::Va {
+	fn image_base(&self) -> super::Va {
 		self.optional_header().ImageBase
 	}
 	

--- a/src/pe64/file.rs
+++ b/src/pe64/file.rs
@@ -83,6 +83,11 @@ unsafe impl<'a> PeObject<'a> for PeFile<'a> {
 	fn align(&self) -> Align {
 		Align::File
 	}
+
+	fn base_addr(&self) -> super::Va {
+		self.optional_header().ImageBase
+	}
+	
 	#[cfg(feature = "serde")]
 	fn serde_name(&self) -> &'static str {
 		"PeFile"

--- a/src/pe64/view.rs
+++ b/src/pe64/view.rs
@@ -120,6 +120,11 @@ unsafe impl<'a> PeObject<'a> for PeView<'a> {
 	fn align(&self) -> Align {
 		Align::Section
 	}
+
+	fn base_addr(&self) -> Va {
+		self.image.as_ptr() as Va
+	}
+
 	#[cfg(feature = "serde")]
 	fn serde_name(&self) -> &'static str {
 		"PeView"


### PR DESCRIPTION
Fixes #266.

Adds a method `image_base(&self) -> Va` to the `Pe` trait:
- For a `PeFile`, returns the preferred virtual address, i.e. `self.optional_header().ImageBase`.
- For a `PeView`, it returns the true virtual address of the image. By default, this is the same as the above, except when constructing via `PeView::module` (uses `base` directly) or via `from_bytes_and_base` (where it is provided by the user).

The return value of this method is used for VA/RVA conversions in the `Pe` trait, replacing `self.optional_header().ImageBase`.