### PR TITLE
Fix pattern proc macro not working in macro_rules

### DIFF
--- a/src/pe32/msvc.rs
+++ b/src/pe32/msvc.rs
@@ -3,8 +3,8 @@ Some MSVC structs for RTTI and exception handling.
 
 References:
 
-[1]: [Reversing Microsoft Visual C++ Part I: Exception Handling](http://www.openrce.org/articles/full_view/21)  
-[2]: [Reversing Microsoft Visual C++ Part II: Classes, Methods and RTTI](http://www.openrce.org/articles/full_view/23)  
+[1]: [Reversing Microsoft Visual C++ Part I: Exception Handling](http://www.openrce.org/articles/full_view/21)
+[2]: [Reversing Microsoft Visual C++ Part II: Classes, Methods and RTTI](http://www.openrce.org/articles/full_view/23)
 */
 
 use std::mem;

--- a/src/pe32/msvc.rs
+++ b/src/pe32/msvc.rs
@@ -3,8 +3,8 @@ Some MSVC structs for RTTI and exception handling.
 
 References:
 
-[1]: [Reversing Microsoft Visual C++ Part I: Exception Handling](http://www.openrce.org/articles/full_view/21)
-[2]: [Reversing Microsoft Visual C++ Part II: Classes, Methods and RTTI](http://www.openrce.org/articles/full_view/23)
+[1]: [Reversing Microsoft Visual C++ Part I: Exception Handling](http://www.openrce.org/articles/full_view/21)  
+[2]: [Reversing Microsoft Visual C++ Part II: Classes, Methods and RTTI](http://www.openrce.org/articles/full_view/23)  
 */
 
 use std::mem;

--- a/src/proc-macros/lib.rs
+++ b/src/proc-macros/lib.rs
@@ -7,17 +7,15 @@ use proc_macro::*;
 /// ```
 #[proc_macro]
 pub fn pattern(input: TokenStream) -> TokenStream {
-    let mut input = input.into_iter().collect::<Vec<_>>();
+	let mut input = input.into_iter().collect::<Vec<_>>();
 
-	// When calling the macro with a macro_rules capture, say $pat, the TokenTree 
+	// When calling the macro with a macro_rules capture, say $pat, the TokenTree
 	// will instead be a no-delimiter Group containing the expanded value of $pat.
 	// Unpack no-delimiter groups to handle this
-    match &input[..] {
-        [TokenTree::Group(g)] if g.delimiter() == Delimiter::None => {
-            input = g.stream().into_iter().collect::<Vec<_>>()
-        }
-        _ => (),
-    };
+	match &input[..] {
+		[TokenTree::Group(g)] if g.delimiter() == Delimiter::None => input = g.stream().into_iter().collect::<Vec<_>>(),
+		_ => (),
+	};
 
 	let string = match &input[..] {
 		[TokenTree::Literal(lit)] => parse_str_literal(&lit),

--- a/src/proc-macros/lib.rs
+++ b/src/proc-macros/lib.rs
@@ -7,7 +7,17 @@ use proc_macro::*;
 /// ```
 #[proc_macro]
 pub fn pattern(input: TokenStream) -> TokenStream {
-	let input = input.into_iter().collect::<Vec<_>>();
+    let mut input = input.into_iter().collect::<Vec<_>>();
+
+	// When calling the macro with a macro_rules capture, say $pat, the TokenTree 
+	// will instead be a no-delimiter Group containing the expanded value of $pat.
+	// Unpack no-delimiter groups to handle this
+    match &input[..] {
+        [TokenTree::Group(g)] if g.delimiter() == Delimiter::None => {
+            input = g.stream().into_iter().collect::<Vec<_>>()
+        }
+        _ => (),
+    };
 
 	let string = match &input[..] {
 		[TokenTree::Literal(lit)] => parse_str_literal(&lit),


### PR DESCRIPTION
Currently, the following use of `pattern!` does not compile:

```rust
use pelite::pattern;
use pelite::pattern::Atom;

macro_rules! forward_pat {
    ($pat:literal) => {
        pattern!($pat)
    }
}

const PAT: &[Atom] = forward_pat("");
```

This is because `macro_rules!` capture expressions, like `$pat`, get wrapped in a `TokenTree::Group` with no delimiter to preserve the order of operations (see https://doc.rust-lang.org/beta/proc_macro/enum.Delimiter.html#variant.None).

This PR fixes this without adding dependencies on other parsing libraries by first checking if the input is a no-delimiter group, and if so, expanding before trying to match on a `TokenTree::Literal`.