### PR TITLE
Replace winapi dependency with windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [".", "./src/proc-macros", "./wasm"]
 [features]
 default = ["mmap", "derive_pod"]
 unsafe_alignment = []
-mmap = ["std", "libc", "winapi"]
+mmap = ["std", "libc", "windows-sys"]
 unstable = []
 derive_pod = ["dataview/derive_pod"]
 std = ["no-std-compat/std"]
@@ -50,7 +50,7 @@ hashbrown = { version = "0.8.0", optional = true }
 libc = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", optional = true, features = ["fileapi", "memoryapi", "handleapi"] }
+windows-sys = { version = ">= 0.59.0, < 0.62", optional = true, features = ["Win32_Storage_FileSystem", "Win32_System_Memory", "Win32_Security"] }
 
 [dev-dependencies]
 rand = "0.5"

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -2,9 +2,9 @@
 Memory map files from disk.
 */
 
-#[cfg(all(windows, feature = "winapi"))]
+#[cfg(all(windows, feature = "windows-sys"))]
 mod windows;
-#[cfg(all(windows, feature = "winapi"))]
+#[cfg(all(windows, feature = "windows-sys"))]
 pub use self::windows::{FileMap, ImageMap};
 
 #[cfg(all(unix, feature = "libc"))]

--- a/src/mmap/windows.rs
+++ b/src/mmap/windows.rs
@@ -4,12 +4,9 @@ use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::path::Path;
 use std::{io, mem, ptr};
 
-use winapi::shared::minwindef::LPVOID;
-use winapi::shared::ntdef::{HANDLE, NULL};
-use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
-use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
-use winapi::um::memoryapi::{CreateFileMappingW, MapViewOfFile, UnmapViewOfFile, VirtualQuery, FILE_MAP_COPY, FILE_MAP_READ};
-use winapi::um::winnt::{FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GENERIC_READ, PAGE_READONLY, SEC_IMAGE};
+use windows_sys::Win32::Storage::FileSystem::{CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, OPEN_EXISTING};
+use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Memory::{CreateFileMappingW, MapViewOfFile, UnmapViewOfFile, VirtualQuery, FILE_MAP_COPY, FILE_MAP_READ, MEMORY_MAPPED_VIEW_ADDRESS, PAGE_READONLY, SEC_IMAGE};
 
 //----------------------------------------------------------------
 
@@ -30,24 +27,24 @@ impl ImageMap {
 			let path: &OsStr = path.as_ref();
 			let mut wpath: Vec<u16> = path.encode_wide().collect();
 			wpath.push(0);
-			CreateFileW(wpath.as_ptr(), GENERIC_READ, FILE_SHARE_READ, ptr::null_mut(), OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL)
+			CreateFileW(wpath.as_ptr(), GENERIC_READ, FILE_SHARE_READ, ptr::null(), OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, ptr::null_mut())
 		};
 		if file != INVALID_HANDLE_VALUE {
 			// Create the image file mapping, `SEC_IMAGE` does its magic thing
-			let map = CreateFileMappingW(file, ptr::null_mut(), PAGE_READONLY | SEC_IMAGE, 0, 0, ptr::null());
+			let map = CreateFileMappingW(file, ptr::null(), PAGE_READONLY | SEC_IMAGE, 0, 0, ptr::null());
 			CloseHandle(file);
-			if map != NULL {
+			if !map.is_null() {
 				// Map view of the file
 				let view = MapViewOfFile(map, FILE_MAP_COPY, 0, 0, 0);
-				if view != ptr::null_mut() {
+				if !view.Value.is_null() {
 					// Trust the OS with correctly mapping the image.
 					// Trust me to have read and understood the documentation.
 					// There is no validation and 64bit headers are used because the offsets are the same for PE32.
 					use crate::image::{IMAGE_DOS_HEADER, IMAGE_NT_HEADERS64};
-					let dos_header = view as *const IMAGE_DOS_HEADER;
-					let nt_header = (view as usize + (*dos_header).e_lfanew as usize) as *const IMAGE_NT_HEADERS64;
+					let dos_header: *const IMAGE_DOS_HEADER = view.Value.cast();
+					let nt_header: *const IMAGE_NT_HEADERS64 = view.Value.add((*dos_header).e_lfanew as usize).cast();
 					let size_of = (*nt_header).OptionalHeader.SizeOfImage;
-					let bytes = ptr::slice_from_raw_parts_mut(view as *mut u8, size_of as usize);
+					let bytes = ptr::slice_from_raw_parts_mut(view.Value.cast(), size_of as usize);
 					return Ok(ImageMap { handle: map, bytes });
 				}
 				let err = io::Error::last_os_error();
@@ -71,7 +68,7 @@ impl AsRef<[u8]> for ImageMap {
 impl Drop for ImageMap {
 	fn drop(&mut self) {
 		unsafe {
-			UnmapViewOfFile((*self.bytes).as_ptr() as LPVOID);
+			UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS { Value: (*self.bytes).as_mut_ptr().cast()});
 			CloseHandle(self.handle);
 		}
 	}
@@ -96,30 +93,30 @@ impl FileMap {
 			let path: &OsStr = path.as_ref();
 			let mut wpath: Vec<u16> = path.encode_wide().collect();
 			wpath.push(0);
-			CreateFileW(wpath.as_ptr(), GENERIC_READ, FILE_SHARE_READ, ptr::null_mut(), OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL)
+			CreateFileW(wpath.as_ptr(), GENERIC_READ, FILE_SHARE_READ, ptr::null(), OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, ptr::null_mut())
 		};
 		if file == INVALID_HANDLE_VALUE {
 			return Err(io::Error::last_os_error());
-		}
+		};
 		// Create the memory file mapping
-		let map = CreateFileMappingW(file, ptr::null_mut(), PAGE_READONLY, 0, 0, ptr::null());
+		let map = CreateFileMappingW(file, ptr::null(), PAGE_READONLY, 0, 0, ptr::null());
 		CloseHandle(file);
-		if map == NULL {
+		if map.is_null() {
 			return Err(io::Error::last_os_error());
-		}
+		};
 		// Map view of the file
 		let view = MapViewOfFile(map, FILE_MAP_READ, 0, 0, 0);
-		if view == ptr::null_mut() {
+		if view.Value.is_null() {
 			let err = io::Error::last_os_error();
 			CloseHandle(map);
 			return Err(err);
 		}
 		// Get the size of the file mapping, should never fail...
 		let mut mem_basic_info = mem::zeroed();
-		let vq_result = VirtualQuery(view, &mut mem_basic_info, mem::size_of_val(&mem_basic_info));
+		let vq_result = VirtualQuery(view.Value, &mut mem_basic_info, mem::size_of_val(&mem_basic_info));
 		debug_assert_eq!(vq_result, mem::size_of_val(&mem_basic_info));
 		// Now have enough information to construct the FileMap
-		let bytes = ptr::slice_from_raw_parts_mut(view as *mut u8, mem_basic_info.RegionSize as usize);
+		let bytes = ptr::slice_from_raw_parts_mut(view.Value.cast(), mem_basic_info.RegionSize as usize);
 		Ok(FileMap { handle: map, bytes })
 	}
 }
@@ -136,7 +133,7 @@ impl AsRef<[u8]> for FileMap {
 impl Drop for FileMap {
 	fn drop(&mut self) {
 		unsafe {
-			UnmapViewOfFile((*self.bytes).as_ptr() as LPVOID);
+			UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS { Value: (*self.bytes).as_mut_ptr().cast()});
 			CloseHandle(self.handle);
 		}
 	}


### PR DESCRIPTION
The winapi and windows-sys crates both provide bindings to Windows APIs, but winapi is a third-party crate and has been unmaintained for 4 years, with its last release over 5 years ago, while windows-sys is an actively-maintained crate from Microsoft.

My main motivation for this change is to deduplicate Windows API bindings in my dependency tree: pelite is the last of my transitive dependencies that depends on winapi instead of windows-sys, and as far as I can tell the Rust ecosystem is generally moving to the latter (or its higher-level sibling, the windows crate), as windows-sys has more than double the all-time downloads (despite being newer than winapi's most recent release). Although winapi still has more direct dependents, windows-sys + windows together have more, so I think it's increasingly likely that others will be be in the same situation as me.

I considered depending on the windows crate instead, but it doesn't really add much value for pelite's usage, and takes longer to build.

I've also replaced a few `as` casts with `ptr::cast()` calls as the latter is slightly less dangerous, and I've adjusted a piece of pointer arithmetic to preserve provenance.