### PR TITLE
Add linux support.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,10 @@ pub use self::pir::Pir;
 pub use dataview::Pod;
 
 /// Defaults to the current platform if it is available.
-#[cfg(all(windows, target_pointer_width = "32"))]
+#[cfg(target_pointer_width = "32")]
 pub use self::pe32 as pe;
 /// Defaults to the current platform if it is available.
-#[cfg(all(windows, target_pointer_width = "64"))]
+#[cfg(target_pointer_width = "64")]
 pub use self::pe64 as pe;
 
 pub mod base_relocs;


### PR DESCRIPTION
## Add linux support.

### Reasoning: 
#### - There are many uses cases for parsing windows binaries on linux.
#### - This crate works perfectly on linux without major changes.
#### - There are separate features flags for features using the windows api, such as winapi and mmap.
