### PR TITLE
Fix panic parsing a malformed VS_VERSIONINFO TLV node

### DIFF
--- a/src/resources/version_info.rs
+++ b/src/resources/version_info.rs
@@ -607,8 +607,14 @@ fn parse_tlv<'a>(state: &mut Parser<'a>) -> Result<TLV<'a>> {
 		return Err(Error::Invalid);
 	}
 
-	// Padding for the Value
-	words = &words[key.len().align_to(2) + 4..];
+	// Padding for the Value. When the declared length is odd, aligning the key up
+	// to a 32-bit boundary can push this offset one past the end of the node, so
+	// bound it instead of slicing unchecked (which panics on malformed input).
+	let value_start = key.len().align_to(2) + 4;
+	if value_start > words.len() {
+		return Err(Error::Invalid);
+	}
+	words = &words[value_start..];
 
 	// Split the remaining words between the Value and Children
 	if value_length > words.len() {
@@ -642,6 +648,13 @@ fn test_parse_tlv_oob() {
 
 	// TLV value field larger than the data
 	parser = Parser::new_zero(&[8, 10, 0, 0, 0, 0]);
+	assert_eq!(parser.next(), Some(Err(Error::Invalid)));
+	assert_eq!(parser.next(), None);
+
+	// TLV whose odd declared length makes the key's 32-bit alignment push the
+	// value offset one word past the node end. Previously sliced unchecked and
+	// panicked; must now report Invalid. (wLength=14 -> 7 words, key "ABC"+nul.)
+	parser = Parser::new_zero(&[14, 0, 1, 65, 66, 67, 0]);
 	assert_eq!(parser.next(), Some(Err(Error::Invalid)));
 	assert_eq!(parser.next(), None);
 }


### PR DESCRIPTION
### Problem

`parse_tlv` skips the value's alignment padding by slicing the word buffer unchecked:

```rust
// Padding for the Value
words = &words[key.len().align_to(2) + 4..];
```

When a node's declared `wLength` is odd, aligning the key length up to a 32-bit boundary can push this offset one word past the end of the node's slice, so the index panics with *"range end index out of range"* instead of returning `Error::Invalid`.

This path is reachable from untrusted input — `VersionInfo::parse` on an attacker-controlled PE — so a crafted version resource crashes any consumer. It is especially bad for callers built with `panic = "abort"`, where it takes down the whole process rather than unwinding.

### Fix

Bound the offset before slicing, mirroring the `value_length > words.len()` guard a few lines below that already handles the same class of malformed input:

```rust
let value_start = key.len().align_to(2) + 4;
if value_start > words.len() {
    return Err(Error::Invalid);
}
words = &words[value_start..];
```

### Test

Adds a regression case to `test_parse_tlv_oob`: `[14, 0, 1, 65, 66, 67, 0]` (`wLength=14` → 7 words, key `"ABC"` + NUL) — the minimal input that previously panicked and must now report `Error::Invalid`.

`cargo test --lib parse_tlv` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)